### PR TITLE
nvme: Return negative errno for failure

### DIFF
--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -239,7 +239,7 @@ static int nvme_ctrlr_set_intel_support_log_pages(struct spdk_nvme_ctrlr *ctrlr)
 					 64, &phys_addr);
 	if (log_page_directory == NULL) {
 		nvme_printf(NULL, "could not allocate log_page_directory\n");
-		return ENXIO;
+		return -ENXIO;
 	}
 
 	status.done = false;
@@ -253,7 +253,7 @@ static int nvme_ctrlr_set_intel_support_log_pages(struct spdk_nvme_ctrlr *ctrlr)
 	if (spdk_nvme_cpl_is_error(&status.cpl)) {
 		nvme_free(log_page_directory);
 		nvme_printf(ctrlr, "nvme_ctrlr_cmd_get_log_page failed!\n");
-		return ENXIO;
+		return -ENXIO;
 	}
 
 	nvme_ctrlr_construct_intel_support_log_page_list(ctrlr, log_page_directory);
@@ -441,7 +441,7 @@ nvme_ctrlr_enable(struct spdk_nvme_ctrlr *ctrlr)
 
 	if (cc.bits.en != 0) {
 		nvme_printf(ctrlr, "%s called with CC.EN = 1\n", __func__);
-		return EINVAL;
+		return -EINVAL;
 	}
 
 	nvme_mmio_write_8(ctrlr, asq, ctrlr->adminq.cmd_bus_addr);
@@ -556,7 +556,7 @@ nvme_ctrlr_identify(struct spdk_nvme_ctrlr *ctrlr)
 	}
 	if (spdk_nvme_cpl_is_error(&status.cpl)) {
 		nvme_printf(ctrlr, "nvme_identify_controller failed!\n");
-		return ENXIO;
+		return -ENXIO;
 	}
 
 	/*
@@ -600,7 +600,7 @@ nvme_ctrlr_set_num_qpairs(struct spdk_nvme_ctrlr *ctrlr)
 	}
 	if (spdk_nvme_cpl_is_error(&status.cpl)) {
 		nvme_printf(ctrlr, "nvme_set_num_queues failed!\n");
-		return ENXIO;
+		return -ENXIO;
 	}
 
 	/*
@@ -758,7 +758,7 @@ nvme_ctrlr_configure_aer(struct spdk_nvme_ctrlr *ctrlr)
 	}
 	if (spdk_nvme_cpl_is_error(&status.cpl)) {
 		nvme_printf(ctrlr, "nvme_ctrlr_cmd_set_async_event_config failed!\n");
-		return ENXIO;
+		return -ENXIO;
 	}
 
 	/* aerl is a zero-based value, so we need to add 1 here. */
@@ -1200,7 +1200,7 @@ spdk_nvme_ctrlr_attach_ns(struct spdk_nvme_ctrlr *ctrlr, uint32_t nsid,
 	}
 	if (spdk_nvme_cpl_is_error(&status.cpl)) {
 		nvme_printf(ctrlr, "spdk_nvme_ctrlr_attach_ns failed!\n");
-		return ENXIO;
+		return -ENXIO;
 	}
 
 	return spdk_nvme_ctrlr_reset(ctrlr);
@@ -1225,7 +1225,7 @@ spdk_nvme_ctrlr_detach_ns(struct spdk_nvme_ctrlr *ctrlr, uint32_t nsid,
 	}
 	if (spdk_nvme_cpl_is_error(&status.cpl)) {
 		nvme_printf(ctrlr, "spdk_nvme_ctrlr_detach_ns failed!\n");
-		return ENXIO;
+		return -ENXIO;
 	}
 
 	return spdk_nvme_ctrlr_reset(ctrlr);
@@ -1277,7 +1277,7 @@ spdk_nvme_ctrlr_delete_ns(struct spdk_nvme_ctrlr *ctrlr, uint32_t nsid)
 	}
 	if (spdk_nvme_cpl_is_error(&status.cpl)) {
 		nvme_printf(ctrlr, "spdk_nvme_ctrlr_delete_ns failed!\n");
-		return ENXIO;
+		return -ENXIO;
 	}
 
 	return spdk_nvme_ctrlr_reset(ctrlr);
@@ -1302,7 +1302,7 @@ spdk_nvme_ctrlr_format(struct spdk_nvme_ctrlr *ctrlr, uint32_t nsid,
 	}
 	if (spdk_nvme_cpl_is_error(&status.cpl)) {
 		nvme_printf(ctrlr, "spdk_nvme_ctrlr_format failed!\n");
-		return ENXIO;
+		return -ENXIO;
 	}
 
 	return spdk_nvme_ctrlr_reset(ctrlr);
@@ -1347,7 +1347,7 @@ spdk_nvme_ctrlr_update_firmware(struct spdk_nvme_ctrlr *ctrlr, void *payload, ui
 		}
 		if (spdk_nvme_cpl_is_error(&status.cpl)) {
 			nvme_printf(ctrlr, "spdk_nvme_ctrlr_fw_image_download failed!\n");
-			return ENXIO;
+			return -ENXIO;
 		}
 		p += transfer;
 		offset += transfer;
@@ -1373,7 +1373,7 @@ spdk_nvme_ctrlr_update_firmware(struct spdk_nvme_ctrlr *ctrlr, void *payload, ui
 	}
 	if (spdk_nvme_cpl_is_error(&status.cpl)) {
 		nvme_printf(ctrlr, "nvme_ctrlr_cmd_fw_commit failed!\n");
-		return ENXIO;
+		return -ENXIO;
 	}
 
 	return spdk_nvme_ctrlr_reset(ctrlr);

--- a/lib/nvme/nvme_ctrlr_cmd.c
+++ b/lib/nvme/nvme_ctrlr_cmd.c
@@ -45,7 +45,7 @@ spdk_nvme_ctrlr_cmd_io_raw(struct spdk_nvme_ctrlr *ctrlr,
 	req = nvme_allocate_request_contig(buf, len, cb_fn, cb_arg);
 
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	memcpy(&req->cmd, cmd, sizeof(req->cmd));
@@ -66,7 +66,7 @@ spdk_nvme_ctrlr_cmd_admin_raw(struct spdk_nvme_ctrlr *ctrlr,
 	req = nvme_allocate_request_contig(buf, len, cb_fn, cb_arg);
 	if (req == NULL) {
 		nvme_mutex_unlock(&ctrlr->ctrlr_lock);
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	memcpy(&req->cmd, cmd, sizeof(req->cmd));
@@ -88,7 +88,7 @@ nvme_ctrlr_cmd_identify_controller(struct spdk_nvme_ctrlr *ctrlr, void *payload,
 					   sizeof(struct spdk_nvme_ctrlr_data),
 					   cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -114,7 +114,7 @@ nvme_ctrlr_cmd_identify_namespace(struct spdk_nvme_ctrlr *ctrlr, uint16_t nsid,
 					   sizeof(struct spdk_nvme_ns_data),
 					   cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -138,7 +138,7 @@ nvme_ctrlr_cmd_create_io_cq(struct spdk_nvme_ctrlr *ctrlr,
 
 	req = nvme_allocate_request_null(cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -168,7 +168,7 @@ nvme_ctrlr_cmd_create_io_sq(struct spdk_nvme_ctrlr *ctrlr,
 
 	req = nvme_allocate_request_null(cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -195,7 +195,7 @@ nvme_ctrlr_cmd_delete_io_cq(struct spdk_nvme_ctrlr *ctrlr, struct spdk_nvme_qpai
 
 	req = nvme_allocate_request_null(cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -214,7 +214,7 @@ nvme_ctrlr_cmd_delete_io_sq(struct spdk_nvme_ctrlr *ctrlr, struct spdk_nvme_qpai
 
 	req = nvme_allocate_request_null(cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -237,7 +237,7 @@ nvme_ctrlr_cmd_attach_ns(struct spdk_nvme_ctrlr *ctrlr, uint32_t nsid,
 					   cb_fn, cb_arg);
 	if (req == NULL) {
 		nvme_mutex_unlock(&ctrlr->ctrlr_lock);
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -264,7 +264,7 @@ nvme_ctrlr_cmd_detach_ns(struct spdk_nvme_ctrlr *ctrlr, uint32_t nsid,
 					   cb_fn, cb_arg);
 	if (req == NULL) {
 		nvme_mutex_unlock(&ctrlr->ctrlr_lock);
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -291,7 +291,7 @@ nvme_ctrlr_cmd_create_ns(struct spdk_nvme_ctrlr *ctrlr, struct spdk_nvme_ns_data
 					   cb_fn, cb_arg);
 	if (req == NULL) {
 		nvme_mutex_unlock(&ctrlr->ctrlr_lock);
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -316,7 +316,7 @@ nvme_ctrlr_cmd_delete_ns(struct spdk_nvme_ctrlr *ctrlr, uint32_t nsid, spdk_nvme
 	req = nvme_allocate_request_null(cb_fn, cb_arg);
 	if (req == NULL) {
 		nvme_mutex_unlock(&ctrlr->ctrlr_lock);
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -341,7 +341,7 @@ nvme_ctrlr_cmd_format(struct spdk_nvme_ctrlr *ctrlr, uint32_t nsid, struct spdk_
 	req = nvme_allocate_request_null(cb_fn, cb_arg);
 	if (req == NULL) {
 		nvme_mutex_unlock(&ctrlr->ctrlr_lock);
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -368,7 +368,7 @@ spdk_nvme_ctrlr_cmd_set_feature(struct spdk_nvme_ctrlr *ctrlr, uint8_t feature,
 	req = nvme_allocate_request_null(cb_fn, cb_arg);
 	if (req == NULL) {
 		nvme_mutex_unlock(&ctrlr->ctrlr_lock);
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -396,7 +396,7 @@ spdk_nvme_ctrlr_cmd_get_feature(struct spdk_nvme_ctrlr *ctrlr, uint8_t feature,
 	req = nvme_allocate_request_null(cb_fn, cb_arg);
 	if (req == NULL) {
 		nvme_mutex_unlock(&ctrlr->ctrlr_lock);
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -447,7 +447,7 @@ spdk_nvme_ctrlr_cmd_get_log_page(struct spdk_nvme_ctrlr *ctrlr, uint8_t log_page
 	req = nvme_allocate_request_contig(payload, payload_size, cb_fn, cb_arg);
 	if (req == NULL) {
 		nvme_mutex_unlock(&ctrlr->ctrlr_lock);
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -471,7 +471,7 @@ nvme_ctrlr_cmd_abort(struct spdk_nvme_ctrlr *ctrlr, uint16_t cid,
 
 	req = nvme_allocate_request_null(cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -494,7 +494,7 @@ nvme_ctrlr_cmd_fw_commit(struct spdk_nvme_ctrlr *ctrlr,
 	req = nvme_allocate_request_null(cb_fn, cb_arg);
 	if (req == NULL) {
 		nvme_mutex_unlock(&ctrlr->ctrlr_lock);
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -522,7 +522,7 @@ nvme_ctrlr_cmd_fw_image_download(struct spdk_nvme_ctrlr *ctrlr,
 					   cb_fn, cb_arg);
 	if (req == NULL) {
 		nvme_mutex_unlock(&ctrlr->ctrlr_lock);
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;

--- a/lib/nvme/nvme_ns.c
+++ b/lib/nvme/nvme_ns.c
@@ -61,7 +61,7 @@ int nvme_ns_identify_update(struct spdk_nvme_ns *ns)
 	}
 	if (spdk_nvme_cpl_is_error(&status.cpl)) {
 		nvme_printf(ctrlr, "nvme_identify_namespace failed\n");
-		return ENXIO;
+		return -ENXIO;
 	}
 
 	ns->sector_size = 1 << nsdata->lbaf[nsdata->flbas.format].lbads;

--- a/lib/nvme/nvme_ns_cmd.c
+++ b/lib/nvme/nvme_ns_cmd.c
@@ -237,7 +237,7 @@ spdk_nvme_ns_cmd_read(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair, vo
 	if (req != NULL) {
 		return nvme_qpair_submit_request(qpair, req);
 	} else {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 }
 
@@ -260,7 +260,7 @@ spdk_nvme_ns_cmd_read_with_md(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *q
 	if (req != NULL) {
 		return nvme_qpair_submit_request(qpair, req);
 	} else {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 }
 
@@ -275,7 +275,7 @@ spdk_nvme_ns_cmd_readv(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
 	struct nvme_payload payload;
 
 	if (reset_sgl_fn == NULL || next_sge_fn == NULL)
-		return EINVAL;
+		return -EINVAL;
 
 	payload.type = NVME_PAYLOAD_TYPE_SGL;
 	payload.md = NULL;
@@ -288,7 +288,7 @@ spdk_nvme_ns_cmd_readv(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
 	if (req != NULL) {
 		return nvme_qpair_submit_request(qpair, req);
 	} else {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 }
 
@@ -310,7 +310,7 @@ spdk_nvme_ns_cmd_write(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
 	if (req != NULL) {
 		return nvme_qpair_submit_request(qpair, req);
 	} else {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 }
 
@@ -332,7 +332,7 @@ spdk_nvme_ns_cmd_write_with_md(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *
 	if (req != NULL) {
 		return nvme_qpair_submit_request(qpair, req);
 	} else {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 }
 
@@ -347,7 +347,7 @@ spdk_nvme_ns_cmd_writev(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
 	struct nvme_payload payload;
 
 	if (reset_sgl_fn == NULL || next_sge_fn == NULL)
-		return EINVAL;
+		return -EINVAL;
 
 	payload.type = NVME_PAYLOAD_TYPE_SGL;
 	payload.md = NULL;
@@ -360,7 +360,7 @@ spdk_nvme_ns_cmd_writev(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
 	if (req != NULL) {
 		return nvme_qpair_submit_request(qpair, req);
 	} else {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 }
 
@@ -375,12 +375,12 @@ spdk_nvme_ns_cmd_write_zeroes(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *q
 	uint64_t		*tmp_lba;
 
 	if (lba_count == 0) {
-		return EINVAL;
+		return -EINVAL;
 	}
 
 	req = nvme_allocate_request_null(cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -403,14 +403,14 @@ spdk_nvme_ns_cmd_deallocate(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpa
 	struct spdk_nvme_cmd	*cmd;
 
 	if (num_ranges == 0 || num_ranges > SPDK_NVME_DATASET_MANAGEMENT_MAX_RANGES) {
-		return EINVAL;
+		return -EINVAL;
 	}
 
 	req = nvme_allocate_request_contig(payload,
 					   num_ranges * sizeof(struct spdk_nvme_dsm_range),
 					   cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -433,7 +433,7 @@ spdk_nvme_ns_cmd_flush(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
 
 	req = nvme_allocate_request_null(cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -459,7 +459,7 @@ spdk_nvme_ns_cmd_reservation_register(struct spdk_nvme_ns *ns,
 					   sizeof(struct spdk_nvme_reservation_register_data),
 					   cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -491,7 +491,7 @@ spdk_nvme_ns_cmd_reservation_release(struct spdk_nvme_ns *ns,
 	req = nvme_allocate_request_contig(payload, sizeof(struct spdk_nvme_reservation_key_data), cb_fn,
 					   cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -524,7 +524,7 @@ spdk_nvme_ns_cmd_reservation_acquire(struct spdk_nvme_ns *ns,
 					   sizeof(struct spdk_nvme_reservation_acquire_data),
 					   cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;
@@ -552,12 +552,12 @@ spdk_nvme_ns_cmd_reservation_report(struct spdk_nvme_ns *ns,
 	struct spdk_nvme_cmd	*cmd;
 
 	if (len % 4)
-		return EINVAL;
+		return -EINVAL;
 	num_dwords = len / 4;
 
 	req = nvme_allocate_request_contig(payload, len, cb_fn, cb_arg);
 	if (req == NULL) {
-		return ENOMEM;
+		return -ENOMEM;
 	}
 
 	cmd = &req->cmd;

--- a/lib/nvme/nvme_qpair.c
+++ b/lib/nvme/nvme_qpair.c
@@ -852,7 +852,7 @@ nvme_qpair_submit_request(struct spdk_nvme_qpair *qpair, struct nvme_request *re
 
 	if (ctrlr->is_failed) {
 		nvme_free_request(req);
-		return ENXIO;
+		return -ENXIO;
 	}
 
 	nvme_qpair_check_enabled(qpair);
@@ -915,7 +915,7 @@ nvme_qpair_submit_request(struct spdk_nvme_qpair *qpair, struct nvme_request *re
 	} else {
 		nvme_assert(0, ("invalid NVMe payload type %d\n", req->payload.type));
 		_nvme_fail_request_bad_vtophys(qpair, tr);
-		return EINVAL;
+		return -EINVAL;
 	}
 
 	nvme_qpair_submit_tracker(qpair, tr);


### PR DESCRIPTION
The conventional rule for returning errno is negative, hence there is no
need to modify caller's code to adjust this NVMe library.

Signed-off-by: Minfei Huang <mnghuan@gmail.com>
Signed-off-by: Minfei Huang <minfei.hmf@alibaba-inc.com>