### PR TITLE
nvme: change retry condition for SPDK_NVME_SC_ABORTED_BY_REQUEST

### DIFF
--- a/lib/nvme/nvme_qpair.c
+++ b/lib/nvme/nvme_qpair.c
@@ -251,7 +251,6 @@ nvme_completion_is_retry(const struct spdk_nvme_cpl *cpl)
 	switch ((int)cpl->status.sct) {
 	case SPDK_NVME_SCT_GENERIC:
 		switch ((int)cpl->status.sc) {
-		case SPDK_NVME_SC_ABORTED_BY_REQUEST:
 		case SPDK_NVME_SC_NAMESPACE_NOT_READY:
 			if (cpl->status.dnr) {
 				return false;
@@ -264,6 +263,7 @@ nvme_completion_is_retry(const struct spdk_nvme_cpl *cpl)
 		case SPDK_NVME_SC_DATA_TRANSFER_ERROR:
 		case SPDK_NVME_SC_ABORTED_POWER_LOSS:
 		case SPDK_NVME_SC_INTERNAL_DEVICE_ERROR:
+		case SPDK_NVME_SC_ABORTED_BY_REQUEST:
 		case SPDK_NVME_SC_ABORTED_SQ_DELETION:
 		case SPDK_NVME_SC_ABORTED_FAILED_FUSED:
 		case SPDK_NVME_SC_ABORTED_MISSING_FUSED:

--- a/test/lib/nvme/unit/nvme_qpair_c/nvme_qpair_ut.c
+++ b/test/lib/nvme/unit/nvme_qpair_c/nvme_qpair_ut.c
@@ -668,7 +668,7 @@ static void test_nvme_completion_is_retry(void)
 	struct spdk_nvme_cpl	cpl = {};
 
 	cpl.status.sct = SPDK_NVME_SCT_GENERIC;
-	cpl.status.sc = SPDK_NVME_SC_ABORTED_BY_REQUEST;
+	cpl.status.sc = SPDK_NVME_SC_NAMESPACE_NOT_READY;
 	cpl.status.dnr = 0;
 	CU_ASSERT_TRUE(nvme_completion_is_retry(&cpl));
 
@@ -688,6 +688,9 @@ static void test_nvme_completion_is_retry(void)
 	CU_ASSERT_FALSE(nvme_completion_is_retry(&cpl));
 
 	cpl.status.sc = SPDK_NVME_SC_INTERNAL_DEVICE_ERROR;
+	CU_ASSERT_FALSE(nvme_completion_is_retry(&cpl));
+
+	cpl.status.sc = SPDK_NVME_SC_ABORTED_BY_REQUEST;
 	CU_ASSERT_FALSE(nvme_completion_is_retry(&cpl));
 
 	cpl.status.sc = SPDK_NVME_SC_ABORTED_FAILED_FUSED;


### PR DESCRIPTION
The comment in the function describes that we should look at the DNR bit only for SPDK_NVME_SC_NAMESPACE_NOT_READY. However, the DNR bit is checked in the case of SPDK_NVME_SC_ABORTED_BY_REQUEST, too. The comment seems correct, so I changed not to check the DNR bit for SPDK_NVME_SC_ABORTED_BY_REQUEST.