### PR TITLE
nvme: fix controller initialization timeout

### DIFF
--- a/lib/nvme/nvme_internal.h
+++ b/lib/nvme/nvme_internal.h
@@ -362,7 +362,7 @@ enum nvme_ctrlr_state {
 	NVME_CTRLR_STATE_READY
 };
 
-#define NVME_TIMEOUT_INFINITE	UINT64_MAX
+#define NVME_TIMEOUT_MAX	UINT64_MAX
 
 /*
  * One of these per allocated PCI device.


### PR DESCRIPTION
There is lack of consideration about overflow of tsc. This pacht fixes it.