### PR TITLE
bdev: fix memory leak in spdk_bdev_io_put_rbuf()

### DIFF
--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -82,6 +82,7 @@ static void
 spdk_bdev_io_put_rbuf(struct spdk_bdev_io *bdev_io)
 {
 	struct rte_mempool *pool;
+	struct spdk_bdev_io *pending_io;
 	void *buf;
 	need_rbuf_tailq_t *tailq;
 	uint64_t length;
@@ -100,9 +101,9 @@ spdk_bdev_io_put_rbuf(struct spdk_bdev_io *bdev_io)
 	if (TAILQ_EMPTY(tailq)) {
 		rte_mempool_put(pool, buf);
 	} else {
-		bdev_io = TAILQ_FIRST(tailq);
-		TAILQ_REMOVE(tailq, bdev_io, rbuf_link);
-		spdk_bdev_io_set_rbuf(bdev_io, buf);
+		pending_io = TAILQ_FIRST(tailq);
+		TAILQ_REMOVE(tailq, pending_io, rbuf_link);
+		spdk_bdev_io_set_rbuf(pending_io, buf);
 	}
 }
 


### PR DESCRIPTION
bdev_io is overwritten when a pending IO exists in spdk_bdev_io_put_rbuf(),  so the bdev_io never goes back to spdk_bdev_g_io_pool. This patch fixes it.