### PR TITLE
bdev: check status parameter instead of bdev_io->status

### DIFF
--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -726,7 +726,7 @@ spdk_bdev_io_complete(struct spdk_bdev_io *bdev_io, enum spdk_bdev_io_status sta
 {
 	if (bdev_io->type == SPDK_BDEV_IO_TYPE_RESET) {
 		/* Successful reset */
-		if (bdev_io->status == SPDK_BDEV_IO_STATUS_SUCCESS) {
+		if (status == SPDK_BDEV_IO_STATUS_SUCCESS) {
 			/* Increase the blockdev generation if it is a hard reset */
 			if (bdev_io->u.reset.type == SPDK_BDEV_RESET_HARD) {
 				bdev_io->bdev->gencnt++;

--- a/test/lib/bdev/bdevio/bdevio.c
+++ b/test/lib/bdev/bdevio/bdevio.c
@@ -488,6 +488,58 @@ blockdev_overlapped_write_read_8k(void)
 	blockdev_write_read(data_length, pattern, offset, expected_rc);
 }
 
+static int
+blockdev_reset(struct io_target *target, void *bdev_task_ctx, int reset_type)
+{
+	int rc;
+
+	complete = 0;
+	completion_status_per_io = SPDK_BDEV_IO_STATUS_FAILED;
+
+	rc = spdk_bdev_reset(target->bdev, reset_type,
+			     quick_test_complete, bdev_task_ctx);
+
+	return rc;
+}
+
+static void
+blockdev_hard_soft_reset(void)
+{
+	struct io_target *target;
+	int	rc;
+
+	target = g_io_targets;
+	while (target != NULL) {
+		rc = blockdev_reset(target, NULL, SPDK_BDEV_RESET_HARD);
+
+		/* If the reset was submitted, the function returns 0 */
+		if (rc != 0) {
+			CU_ASSERT_EQUAL(completion_status_per_io, SPDK_BDEV_IO_STATUS_FAILED);
+		} else {
+			check_io_completion();
+			/* If the reset was successful, the gencnt is incremented */
+			if (completion_status_per_io == SPDK_BDEV_IO_STATUS_SUCCESS) {
+				CU_ASSERT_EQUAL(target->bdev->gencnt, 1);
+			} else {
+				CU_ASSERT_EQUAL(target->bdev->gencnt, 0);
+			}
+		}
+
+		target->bdev->gencnt = 0;
+		rc = blockdev_reset(target, NULL, SPDK_BDEV_RESET_SOFT);
+
+		/* If the reset was submitted, the function returns 0 */
+		if (rc != 0) {
+			CU_ASSERT_EQUAL(completion_status_per_io, SPDK_BDEV_IO_STATUS_FAILED);
+		} else {
+			check_io_completion();
+			/* The gencnt is always 0 regardless of the failure or success. */
+			CU_ASSERT_EQUAL(target->bdev->gencnt, 0);
+		}
+
+		target = target->next;
+	}
+}
 
 int
 main(int argc, char **argv)
@@ -534,6 +586,8 @@ main(int argc, char **argv)
 			       blockdev_write_read_max_offset) == NULL
 		|| CU_add_test(suite, "blockdev write read 8k on overlapped address offset",
 			       blockdev_overlapped_write_read_8k) == NULL
+		|| CU_add_test(suite, "blockdev hard & soft reset",
+			       blockdev_hard_soft_reset) == NULL
 	) {
 		CU_cleanup_registry();
 		return CU_get_error();


### PR DESCRIPTION
A status member of spdk_bdev_io structure is set after the if block.
Therefore a status parameter should be checked instead of a status member in the if block.