### PR TITLE
fio_plugin: fix compilation issue with Tomohiro's patch

### DIFF
--- a/examples/nvme/fio_plugin/fio_plugin.c
+++ b/examples/nvme/fio_plugin/fio_plugin.c
@@ -134,7 +134,7 @@ attach_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr *ctr
 	int found_slot   = spdk_pci_device_get_dev(dev);
 	int found_func   = spdk_pci_device_get_func(dev);
 	struct thread_data 	*td = cb_ctx;
-	struct spdk_fio_thread	*fio_thread = td->io_ops->data;
+	struct spdk_fio_thread	*fio_thread = td->io_ops_data;
 	struct spdk_fio_ctrlr	*fio_ctrlr;
 	struct spdk_fio_ns	*fio_ns;
 	struct fio_file *f;
@@ -197,7 +197,7 @@ static int spdk_fio_setup(struct thread_data *td)
 	fio_thread = calloc(1, sizeof(*fio_thread));
 	assert(fio_thread != NULL);
 
-	td->io_ops->data = fio_thread;
+	td->io_ops_data = fio_thread;
 	fio_thread->td = td;
 
 	fio_thread->iocq = calloc(td->o.iodepth + 1, sizeof(struct io_u *));
@@ -250,7 +250,7 @@ static void spdk_fio_iomem_free(struct thread_data *td)
 
 static int spdk_fio_io_u_init(struct thread_data *td, struct io_u *io_u)
 {
-	struct spdk_fio_thread	*fio_thread = td->io_ops->data;
+	struct spdk_fio_thread	*fio_thread = td->io_ops_data;
 	struct spdk_fio_request	*fio_req;
 
 	fio_req = calloc(1, sizeof(*fio_req));
@@ -290,7 +290,7 @@ static void spdk_fio_completion_cb(void *ctx, const struct spdk_nvme_cpl *cpl)
 static int spdk_fio_queue(struct thread_data *td, struct io_u *io_u)
 {
 	int rc = 1;
-	struct spdk_fio_thread	*fio_thread = td->io_ops->data;
+	struct spdk_fio_thread	*fio_thread = td->io_ops_data;
 	struct spdk_fio_request	*fio_req = io_u->engine_data;
 	struct spdk_fio_ctrlr	*fio_ctrlr;
 	struct spdk_fio_ns	*fio_ns;
@@ -342,7 +342,7 @@ static int spdk_fio_queue(struct thread_data *td, struct io_u *io_u)
 
 static struct io_u *spdk_fio_event(struct thread_data *td, int event)
 {
-	struct spdk_fio_thread *fio_thread = td->io_ops->data;
+	struct spdk_fio_thread *fio_thread = td->io_ops_data;
 	int idx = (fio_thread->getevents_start + event) % td->o.iodepth;
 
 	if (event > (int)fio_thread->getevents_count) {
@@ -355,7 +355,7 @@ static struct io_u *spdk_fio_event(struct thread_data *td, int event)
 static int spdk_fio_getevents(struct thread_data *td, unsigned int min,
 			      unsigned int max, const struct timespec *t)
 {
-	struct spdk_fio_thread *fio_thread = td->io_ops->data;
+	struct spdk_fio_thread *fio_thread = td->io_ops_data;
 	struct spdk_fio_ctrlr *fio_ctrlr;
 	unsigned int count = 0;
 	struct timespec t0, t1;
@@ -404,7 +404,7 @@ static int spdk_fio_invalidate(struct thread_data *td, struct fio_file *f)
 
 static void spdk_fio_cleanup(struct thread_data *td)
 {
-	struct spdk_fio_thread	*fio_thread = td->io_ops->data;
+	struct spdk_fio_thread	*fio_thread = td->io_ops_data;
 	struct spdk_fio_ctrlr	*fio_ctrlr, *fio_ctrlr_tmp;
 	struct spdk_fio_ns	*fio_ns, *fio_ns_tmp;
 


### PR DESCRIPTION
```
[PATCH] Don't malloc/memcpy ioengine_ops on td initialization
```
