### PR TITLE
 Fix some cppcheck errors on lib/bdev & lib/iscsi & lib/scsi.

### DIFF
--- a/lib/bdev/malloc/blockdev_malloc.c
+++ b/lib/bdev/malloc/blockdev_malloc.c
@@ -126,7 +126,7 @@ blockdev_malloc_read(struct malloc_disk *mdisk, struct copy_task *copy_req,
 	SPDK_TRACELOG(SPDK_TRACE_MALLOC, "read %lu bytes from offset %#lx to %p\n",
 		      nbytes, offset, buf);
 
-	return spdk_copy_submit(copy_req, buf, (void *)((char *)mdisk->malloc_buf + offset),
+	return spdk_copy_submit(copy_req, buf, mdisk->malloc_buf + offset,
 				nbytes, malloc_done);
 }
 
@@ -140,7 +140,7 @@ blockdev_malloc_writev(struct malloc_disk *mdisk, struct copy_task *copy_req,
 	SPDK_TRACELOG(SPDK_TRACE_MALLOC, "wrote %lu bytes to offset %#lx from %p\n",
 		      iov->iov_len, offset, iov->iov_base);
 
-	return spdk_copy_submit(copy_req, (void *)((char *)mdisk->malloc_buf + offset),
+	return spdk_copy_submit(copy_req, mdisk->malloc_buf + offset,
 				iov->iov_base, len, malloc_done);
 }
 
@@ -201,8 +201,8 @@ static int _blockdev_malloc_submit_request(struct spdk_bdev_io *bdev_io)
 	switch (bdev_io->type) {
 	case SPDK_BDEV_IO_TYPE_READ:
 		if (bdev_io->u.read.buf == NULL) {
-			bdev_io->u.read.buf = (void *)((char *)(((struct malloc_disk *)bdev_io->ctx)->malloc_buf) +
-					      bdev_io->u.read.offset);
+			bdev_io->u.read.buf = ((struct malloc_disk *)bdev_io->ctx)->malloc_buf +
+					      bdev_io->u.read.offset;
 			spdk_bdev_io_complete(spdk_bdev_io_from_ctx(bdev_io->driver_ctx),
 					      SPDK_BDEV_IO_STATUS_SUCCESS);
 			return 0;

--- a/lib/iscsi/conn.c
+++ b/lib/iscsi/conn.c
@@ -380,8 +380,7 @@ spdk_iscsi_conn_construct(struct spdk_iscsi_portal *portal,
 		SPDK_ERRLOG("iscsi_conn_params_init() failed\n");
 error_return:
 		spdk_iscsi_param_free(conn->params);
-		if (conn)
-			free_conn(conn);
+		free_conn(conn);
 		return -1;
 	}
 	conn->is_idle = 0;

--- a/lib/iscsi/iscsi_subsystem.c
+++ b/lib/iscsi/iscsi_subsystem.c
@@ -277,42 +277,40 @@ spdk_iscsi_config_dump_target_nodes(FILE *fp)
 				target->map[m].ig->tag);
 		}
 
-		if (dev) {
-			const char *authmethod = "None";
-			char authgroup[32] = "None";
-			const char *usedigest = "Auto";
+		const char *authmethod = "None";
+		char authgroup[32] = "None";
+		const char *usedigest = "Auto";
 
-			if (target->auth_chap_disabled)
-				authmethod = "None";
-			else if (!target->auth_chap_required)
-				authmethod = "Auto";
-			else if (target->auth_chap_mutual)
-				authmethod = "CHAP Mutual";
-			else
-				authmethod = "CHAP";
+		if (target->auth_chap_disabled)
+			authmethod = "None";
+		else if (!target->auth_chap_required)
+			authmethod = "Auto";
+		else if (target->auth_chap_mutual)
+			authmethod = "CHAP Mutual";
+		else
+			authmethod = "CHAP";
 
-			if (target->auth_group > 0)
-				snprintf(authgroup, sizeof(authgroup), "AuthGroup%d", target->auth_group);
+		if (target->auth_group > 0)
+			snprintf(authgroup, sizeof(authgroup), "AuthGroup%d", target->auth_group);
 
-			if (target->header_digest)
-				usedigest = "Header";
-			else if (target->data_digest)
-				usedigest = "Data";
+		if (target->header_digest)
+			usedigest = "Header";
+		else if (target->data_digest)
+			usedigest = "Data";
 
-			fprintf(fp, TARGET_NODE_AUTH_TMPL,
-				authmethod, authgroup, usedigest);
+		fprintf(fp, TARGET_NODE_AUTH_TMPL,
+			authmethod, authgroup, usedigest);
 
-			for (l = 0; l < dev->maxlun; l++) {
-				if (NULL == dev->lun[l]) continue;
+		for (l = 0; l < dev->maxlun; l++) {
+			if (NULL == dev->lun[l]) continue;
 
-				fprintf(fp, TARGET_NODE_LUN_TMPL,
-					dev->lun[l]->id,
-					dev->lun[l]->name);
-			}
-
-			fprintf(fp, TARGET_NODE_QD_TMPL,
-				target->queue_depth);
+			fprintf(fp, TARGET_NODE_LUN_TMPL,
+				dev->lun[l]->id,
+				dev->lun[l]->name);
 		}
+
+		fprintf(fp, TARGET_NODE_QD_TMPL,
+			target->queue_depth);
 	}
 }
 

--- a/lib/iscsi/md5.c
+++ b/lib/iscsi/md5.c
@@ -66,7 +66,7 @@ int spdk_md5update(struct spdk_md5ctx *md5ctx, const void *data, size_t len)
 
 	if (md5ctx == NULL)
 		return -1;
-	if (data == NULL || len <= 0)
+	if (data == NULL || len == 0)
 		return 0;
 	rc = MD5_Update(&md5ctx->md5ctx, data, len);
 	return rc;

--- a/lib/scsi/scsi_bdev.c
+++ b/lib/scsi/scsi_bdev.c
@@ -66,7 +66,8 @@ spdk_bdev_scsi_set_local_naa(char *name, uint8_t *buf)
 {
 	int i, value, count = 0;
 	uint64_t naa, local_value;
-	for (i = 0; (name[i] != '\0') && (i < 16); i++) {
+
+	for (i = 0; (i < 16) && (name[i] != '\0'); i++) {
 		value = spdk_hex2bin(name[i]);
 		if (i % 2) {
 			buf[count++] |= value << 4;

--- a/test/lib/bdev/bdevperf/bdevperf.c
+++ b/test/lib/bdev/bdevperf/bdevperf.c
@@ -434,7 +434,7 @@ performance_dump(int io_time)
 		target = head[index];
 		if (target != NULL) {
 			lcore_id = target->lcore;
-			printf("\r Logical core: %d\n", lcore_id);
+			printf("\r Logical core: %u\n", lcore_id);
 		}
 		while (target != NULL) {
 			io_per_second = (float)target->io_completed /


### PR DESCRIPTION
 Fixed error types:
 1 nullPointerRedundantCheck;
 2 unsignedLessThanZero;
 3 arithOperationsOnVoidPointer;
 4 invalidPrintfArgType_sint;
 5 arrayIndexThenCheck