### PR TITLE
Modified: the nvme_ctrlr_cmd_identify_namespace() func. selectively f…

### DIFF
--- a/examples/nvme/identify/identify.c
+++ b/examples/nvme/identify/identify.c
@@ -333,7 +333,7 @@ print_namespace(struct spdk_nvme_ns *ns)
 	uint32_t				i;
 	uint32_t				flags;
 
-	nsdata = spdk_nvme_ns_get_data(ns);
+	nsdata = spdk_nvme_ns_get_data(ns, 0);
 	flags  = spdk_nvme_ns_get_flags(ns);
 
 	printf("Namespace ID:%d\n", spdk_nvme_ns_get_id(ns));

--- a/examples/nvme/nvme_manage/nvme_manage.c
+++ b/examples/nvme/nvme_manage/nvme_manage.c
@@ -229,7 +229,10 @@ display_namespace(struct spdk_nvme_ns *ns)
 	const struct spdk_nvme_ns_data		*nsdata;
 	uint32_t				i;
 
-	nsdata = spdk_nvme_ns_get_data(ns);
+	nsdata = spdk_nvme_ns_get_data(ns, 0);
+
+    if (!nsdata->nsze)
+        return;
 
 	printf("Namespace ID:%d\n", spdk_nvme_ns_get_id(ns));
 
@@ -728,7 +731,7 @@ format_nvm(void)
 		return;
 	}
 
-	nsdata = spdk_nvme_ns_get_data(ns);
+	nsdata = spdk_nvme_ns_get_data(ns, 0);
 
 	printf("Please Input Secure Erase Setting: \n");
 	printf("	0: No secure erase operation requested\n");

--- a/include/spdk/nvme.h
+++ b/include/spdk/nvme.h
@@ -529,7 +529,7 @@ int spdk_nvme_ctrlr_update_firmware(struct spdk_nvme_ctrlr *ctrlr, void *payload
  * This function is thread safe and can be called at any point while the controller is attached to
  *  the SPDK NVMe driver.
  */
-const struct spdk_nvme_ns_data *spdk_nvme_ns_get_data(struct spdk_nvme_ns *ns);
+const struct spdk_nvme_ns_data *spdk_nvme_ns_get_data(struct spdk_nvme_ns *ns, uint32_t ns_allocated);
 
 /**
  * \brief Get the namespace id (index number) from the given namespace handle.

--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -676,6 +676,7 @@ nvme_ctrlr_construct_namespaces(struct spdk_nvme_ctrlr *ctrlr)
 {
 	uint32_t i, nn = ctrlr->cdata.nn;
 	uint64_t phys_addr = 0;
+    uint32_t ns_allocated = 1;
 
 	if (nn == 0) {
 		nvme_printf(ctrlr, "controller has 0 namespaces\n");
@@ -707,7 +708,10 @@ nvme_ctrlr_construct_namespaces(struct spdk_nvme_ctrlr *ctrlr)
 		struct spdk_nvme_ns	*ns = &ctrlr->ns[i];
 		uint32_t 		nsid = i + 1;
 
-		if (nvme_ns_construct(ns, nsid, ctrlr) != 0) {
+        /* 
+        *   necessarry to consider whether the namesspace is allocated.
+        */
+		if (nvme_ns_construct(ns, nsid, ctrlr, ns_allocated) != 0) {
 			goto fail;
 		}
 	}

--- a/lib/nvme/nvme_ctrlr_cmd.c
+++ b/lib/nvme/nvme_ctrlr_cmd.c
@@ -104,7 +104,7 @@ nvme_ctrlr_cmd_identify_controller(struct spdk_nvme_ctrlr *ctrlr, void *payload,
 
 int
 nvme_ctrlr_cmd_identify_namespace(struct spdk_nvme_ctrlr *ctrlr, uint16_t nsid,
-				  void *payload, spdk_nvme_cmd_cb cb_fn, void *cb_arg)
+				  void *payload, spdk_nvme_cmd_cb cb_fn, void *cb_arg, uint32_t ns_allocated)
 {
 	struct nvme_request *req;
 	struct spdk_nvme_cmd *cmd;
@@ -121,7 +121,11 @@ nvme_ctrlr_cmd_identify_namespace(struct spdk_nvme_ctrlr *ctrlr, uint16_t nsid,
 	/*
 	 * TODO: create an identify command data structure
 	 */
-	cmd->cdw10 = SPDK_NVME_IDENTIFY_NS;
+    if (ns_allocated)
+        cmd->cdw10 = SPDK_NVME_IDENTIFY_NS_ALLOCATED;
+    else
+        cmd->cdw10 = SPDK_NVME_IDENTIFY_NS;
+
 	cmd->nsid = nsid;
 
 	return nvme_ctrlr_submit_admin_request(ctrlr, req);

--- a/lib/nvme/nvme_internal.h
+++ b/lib/nvme/nvme_internal.h
@@ -515,7 +515,7 @@ int	nvme_ctrlr_cmd_identify_controller(struct spdk_nvme_ctrlr *ctrlr,
 		spdk_nvme_cmd_cb cb_fn, void *cb_arg);
 int	nvme_ctrlr_cmd_identify_namespace(struct spdk_nvme_ctrlr *ctrlr,
 		uint16_t nsid, void *payload,
-		spdk_nvme_cmd_cb cb_fn, void *cb_arg);
+		spdk_nvme_cmd_cb cb_fn, void *cb_arg, uint32_t ns_allocated);
 int	nvme_ctrlr_cmd_create_io_cq(struct spdk_nvme_ctrlr *ctrlr,
 				    struct spdk_nvme_qpair *io_que,
 				    spdk_nvme_cmd_cb cb_fn, void *cb_arg);
@@ -574,7 +574,7 @@ void	nvme_qpair_reset(struct spdk_nvme_qpair *qpair);
 void	nvme_qpair_fail(struct spdk_nvme_qpair *qpair);
 
 int	nvme_ns_construct(struct spdk_nvme_ns *ns, uint16_t id,
-			  struct spdk_nvme_ctrlr *ctrlr);
+			  struct spdk_nvme_ctrlr *ctrlr, uint32_t ns_allocated);
 void	nvme_ns_destruct(struct spdk_nvme_ns *ns);
 
 struct nvme_request *nvme_allocate_request(const struct nvme_payload *payload,

--- a/lib/nvme/nvme_ns.c
+++ b/lib/nvme/nvme_ns.c
@@ -40,7 +40,7 @@ _nvme_ns_get_data(struct spdk_nvme_ns *ns)
 }
 
 static
-int nvme_ns_identify_update(struct spdk_nvme_ns *ns)
+int nvme_ns_identify_update(struct spdk_nvme_ns *ns, uint32_t ns_allocated)
 {
 	struct nvme_completion_poll_status	status;
 	struct spdk_nvme_ns_data		*nsdata;
@@ -49,7 +49,7 @@ int nvme_ns_identify_update(struct spdk_nvme_ns *ns)
 	nsdata = _nvme_ns_get_data(ns);
 	status.done = false;
 	rc = nvme_ctrlr_cmd_identify_namespace(ns->ctrlr, ns->id, nsdata,
-					       nvme_completion_poll_cb, &status);
+					       nvme_completion_poll_cb, &status, ns_allocated);
 	if (rc != 0) {
 		return rc;
 	}
@@ -165,14 +165,14 @@ spdk_nvme_ns_get_md_size(struct spdk_nvme_ns *ns)
 }
 
 const struct spdk_nvme_ns_data *
-spdk_nvme_ns_get_data(struct spdk_nvme_ns *ns)
+spdk_nvme_ns_get_data(struct spdk_nvme_ns *ns, uint32_t ns_allocated)
 {
-	nvme_ns_identify_update(ns);
+	nvme_ns_identify_update(ns, ns_allocated);
 	return _nvme_ns_get_data(ns);
 }
 
 int nvme_ns_construct(struct spdk_nvme_ns *ns, uint16_t id,
-		      struct spdk_nvme_ctrlr *ctrlr)
+		      struct spdk_nvme_ctrlr *ctrlr, uint32_t ns_allocated)
 {
 	uint32_t				pci_devid;
 
@@ -187,7 +187,7 @@ int nvme_ns_construct(struct spdk_nvme_ns *ns, uint16_t id,
 		ns->stripe_size = (1 << ctrlr->cdata.vs[3]) * ctrlr->min_page_size;
 	}
 
-	return nvme_ns_identify_update(ns);
+	return nvme_ns_identify_update(ns, ns_allocated);
 }
 
 void nvme_ns_destruct(struct spdk_nvme_ns *ns)

--- a/test/lib/nvme/e2edp/nvme_dp.c
+++ b/test/lib/nvme/e2edp/nvme_dp.c
@@ -423,7 +423,7 @@ write_read_e2e_dp_tests(struct dev *dev, nvme_build_io_req_fn_t build_io_fn, con
 	if (!(spdk_nvme_ns_get_flags(ns) & SPDK_NVME_NS_DPS_PI_SUPPORTED))
 		return 0;
 
-	nsdata = spdk_nvme_ns_get_data(ns);
+	nsdata = spdk_nvme_ns_get_data(ns, 0);
 	if (!nsdata || !spdk_nvme_ns_get_sector_size(ns)) {
 		fprintf(stderr, "Empty nsdata or wrong sector size\n");
 		return 0;

--- a/test/lib/nvme/sgl/nvme_sgl.c
+++ b/test/lib/nvme/sgl/nvme_sgl.c
@@ -254,7 +254,7 @@ writev_readv_tests(struct dev *dev, nvme_build_io_req_fn_t build_io_fn, const ch
 		fprintf(stderr, "Null namespace\n");
 		return 0;
 	}
-	nsdata = spdk_nvme_ns_get_data(ns);
+	nsdata = spdk_nvme_ns_get_data(ns, 0);
 	if (!nsdata || !spdk_nvme_ns_get_sector_size(ns)) {
 		fprintf(stderr, "Empty nsdata or wrong sector size\n");
 		return 0;

--- a/test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
+++ b/test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
@@ -275,7 +275,7 @@ nvme_ns_destruct(struct spdk_nvme_ns *ns)
 
 int
 nvme_ns_construct(struct spdk_nvme_ns *ns, uint16_t id,
-		  struct spdk_nvme_ctrlr *ctrlr)
+		  struct spdk_nvme_ctrlr *ctrlr, uint32_t ns_allocated)
 {
 	return 0;
 }


### PR DESCRIPTION
Hi maintainers, 

My name is Yongseok, working on NVMe SSDs at SK telecom. Our team is very interested in your SPDK project. 

Particularly, I see the current version of the identify_ns() function do not consider IDENTIFY_NS_ALLOCATED (11h). Then, some tests related to the identify_ns() function fails improperly.  

Please review and have it involved in your project. 