### PR TITLE
fixed the bug: If mask not specified on command line or in configurat…

### DIFF
--- a/include/spdk/event.h
+++ b/include/spdk/event.h
@@ -110,7 +110,7 @@ typedef void (*spdk_sighandler_t)(int);
 #define SPDK_APP_DPDK_DEFAULT_MEM_SIZE		2048
 #define SPDK_APP_DPDK_DEFAULT_MASTER_CORE	0
 #define SPDK_APP_DPDK_DEFAULT_MEM_CHANNEL	4
-#define SPDK_APP_DPDK_DEFAULT_CORE_MASK		"0x1"
+#define SPDK_APP_DPDK_DEFAULT_CORE_MASK		NULL
 
 /**
  * \brief Event framework initialization options

--- a/lib/event/dpdk_init.c
+++ b/lib/event/dpdk_init.c
@@ -82,7 +82,8 @@ spdk_free_ealargs(void)
 static unsigned long long
 spdk_get_eal_coremask(const char *coremask)
 {
-	unsigned long long core_mask, max_coremask = 0;
+	unsigned long long core_mask = 0;
+	unsigned long long max_coremask = 0;
 	int num_cores_online;
 
 	num_cores_online = sysconf(_SC_NPROCESSORS_ONLN);
@@ -97,9 +98,12 @@ spdk_get_eal_coremask(const char *coremask)
 		}
 	}
 
-	core_mask = strtoull(coremask, NULL, 16);
-	core_mask &= max_coremask;
-
+	if(coremask != NULL) {
+		core_mask = strtoull(coremask, NULL, 16);
+		core_mask &= max_coremask;
+	} else {
+		core_mask = max_coremask;
+	}
 	return core_mask;
 }
 


### PR DESCRIPTION
There is comment from existing iscsi code: “If mask not specified on command line or in configuration file, reactor_mask will be NULL which will enable all cores to run reactors. “ From this comment, I think the value of SPDK_APP_DPDK_DEFAULT_CORE_MASK should be NULL, not "0x1". I also did experiment to test it: if the user didn’t specify reactor_mask, only the first cpu core would be used to run reactor(only one reactor thread). After my modification, all CPU cores works.