### PR TITLE
iscsi: fix comment issue. If not specified reactor mask , we only use…

### DIFF
--- a/etc/spdk/iscsi.conf.in
+++ b/etc/spdk/iscsi.conf.in
@@ -16,7 +16,7 @@
 
   # Users can restrict work items to only run on certain cores by
   #  specifying a ReactorMask.  Default is to allow work items to run
-  #  on all cores.
+  #  on core 0.
   #ReactorMask 0xFFFF
 
   # Tracepoint group mask for spdk trace buffers

--- a/lib/event/app.c
+++ b/lib/event/app.c
@@ -320,8 +320,8 @@ spdk_app_init(struct spdk_app_opts *opts)
 
 	/*
 	 * If mask not specified on command line or in configuration file,
-	 *  reactor_mask will be NULL which will enable all cores to run
-	 *  reactors.
+	 *  reactor_mask will be 0x1 which will enable core 0 to run one
+	 *  reactor.
 	 */
 	if (spdk_reactors_init(opts->reactor_mask, opts->max_delay_us)) {
 		fprintf(stderr, "Invalid reactor mask.\n");


### PR DESCRIPTION
The comment in the code is not consistent with the code implementation. As the discussion, we decide to change the comment.