### PR TITLE
Modified these files to add a timeout feature.

### DIFF
--- a/CONFIG
+++ b/CONFIG
@@ -72,3 +72,6 @@ FIO_SOURCE_DIR?=/usr/src/fio
 # Enable RDMA support for the NVMf target.
 # Requires ibverbs development libraries.
 CONFIG_RDMA?=n
+
+# Change NVMe IO timeout value.
+CONFIG_NVME_IO_TIMEOUT=30

--- a/lib/nvme/Makefile
+++ b/lib/nvme/Makefile
@@ -35,6 +35,9 @@ SPDK_ROOT_DIR := $(abspath $(CURDIR)/../..)
 include $(SPDK_ROOT_DIR)/mk/spdk.common.mk
 
 CFLAGS += $(DPDK_INC) -include $(CONFIG_NVME_IMPL)
+ifdef CONFIG_NVME_IO_TIMEOUT
+CFLAGS += -DNVME_IO_TIMEOUT=$(CONFIG_NVME_IO_TIMEOUT)
+endif
 C_SRCS = nvme_ctrlr_cmd.c nvme_ctrlr.c nvme_ns_cmd.c nvme_ns.c nvme_qpair.c nvme.c nvme_intel.c
 LIBNAME = nvme
 

--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -1132,7 +1132,8 @@ nvme_ctrlr_construct(struct spdk_nvme_ctrlr *ctrlr, void *devhandle)
 
 	TAILQ_INIT(&ctrlr->free_io_qpairs);
 	TAILQ_INIT(&ctrlr->active_io_qpairs);
-
+	ctrlr->abort_in_progress = 0;
+	ctrlr->hz = rte_get_timer_hz();
 	pthread_mutex_init_recursive(&ctrlr->ctrlr_lock);
 
 	return 0;

--- a/test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
+++ b/test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
@@ -33,6 +33,7 @@
 
 #include "spdk_cunit.h"
 
+uint64_t rte_get_timer_hz(void);
 #include "nvme/nvme_ctrlr.c"
 
 struct nvme_driver _g_nvme_driver = {
@@ -1111,6 +1112,12 @@ test_nvme_ctrlr_alloc_cmb(void)
 
 	rc = nvme_ctrlr_alloc_cmb(&ctrlr, 0x8000000, 0x1000, &offset);
 	CU_ASSERT(rc == -1);
+}
+
+uint64_t
+rte_get_timer_hz()
+{
+	return 0;
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Modified these files
CONFIG
lib/nvme/Makefile
lib/nvme/nvme_ctrlr.c
lib/nvme/nvme_internal.h
lib/nvme/nvme_qpair.c
test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
test/lib/nvme/unit/nvme_qpair_c/nvme_qpair_ut.c
to add a timeout feature. Default timeout is 30 seconds.The value can be changed in spdk/CONFIG file and then compiled.
