### PR TITLE
Don't bind rbd related threads to the cores which runs reactors, in o…

### DIFF
--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -48,6 +48,7 @@ extern "C" {
 #include <stdio.h>
 
 struct spdk_pci_device;
+typedef int (*app_callback)(void * args);
 
 /**
  * Allocate a pinned, physically contiguous memory buffer with the
@@ -190,6 +191,8 @@ int spdk_pci_device_cfg_read32(struct spdk_pci_device *dev, uint32_t *value, uin
 int spdk_pci_device_cfg_write32(struct spdk_pci_device *dev, uint32_t value, uint32_t offset);
 
 bool spdk_pci_device_compare_addr(struct spdk_pci_device *dev, struct spdk_pci_addr *addr);
+
+int spdk_use_all_cpu_cores_for_app(app_callback cb, void *args);
 
 #ifdef __cplusplus
 }

--- a/lib/bdev/rbd/Makefile
+++ b/lib/bdev/rbd/Makefile
@@ -34,7 +34,7 @@
 SPDK_ROOT_DIR := $(abspath $(CURDIR)/../../..)
 include $(SPDK_ROOT_DIR)/mk/spdk.common.mk
 
-CFLAGS += -I$(SPDK_ROOT_DIR)/lib/bdev/
+CFLAGS += $(DPDK_INC) -I$(SPDK_ROOT_DIR)/lib/bdev/
 C_SRCS = blockdev_rbd.c blockdev_rbd_rpc.c
 LIBNAME = bdev_rbd
 

--- a/lib/bdev/rbd/blockdev_rbd.c
+++ b/lib/bdev/rbd/blockdev_rbd.c
@@ -43,6 +43,10 @@
 #include <inttypes.h>
 #include <poll.h>
 #include <sys/eventfd.h>
+#include <rte_config.h>
+#include <rte_ring.h>
+#include <rte_mempool.h>
+#include <rte_lcore.h>
 #include <rbd/librbd.h>
 #include <rados/librados.h>
 
@@ -52,6 +56,7 @@
 #include "spdk/io_channel.h"
 
 #include "bdev_module.h"
+#include "blockdev_rbd.h"
 
 static TAILQ_HEAD(, blockdev_rbd_pool_info) g_rbd_pools = TAILQ_HEAD_INITIALIZER(g_rbd_pools);
 static TAILQ_HEAD(, blockdev_rbd) g_rbds = TAILQ_HEAD_INITIALIZER(g_rbds);
@@ -236,6 +241,7 @@ blockdev_rbd_start_aio(rbd_image_t image, struct blockdev_rbd_io *cmd,
 }
 
 static int blockdev_rbd_library_init(void);
+static int blockdev_rbd_thread_init(struct blockdev_rbd_io_channel *channel);
 static void blockdev_rbd_library_fini(void);
 
 static int
@@ -450,9 +456,8 @@ blockdev_rbd_create_cb(void *io_device, uint32_t priority,
 		goto err;
 	}
 
-	ret = rbd_open(ch->io_ctx, ch->disk->rbd_name, &ch->image, NULL);
+	ret = blockdev_rbd_thread_init(ch);
 	if (ret < 0) {
-		SPDK_ERRLOG("Failed to open specified rbd device\n");
 		goto err;
 	}
 
@@ -616,6 +621,75 @@ spdk_bdev_rbd_create(const char *pool_name, const char *rbd_name, uint32_t block
 				sizeof(struct blockdev_rbd_io_channel));
 	spdk_bdev_register(&rbd->disk);
 	return 0;
+}
+
+#define BDEV_SYS_CPU_DIR "/sys/devices/system/cpu/cpu%u"
+#define BDEV_CORE_ID_FILE "topology/core_id"
+#define BDEV_CPU_PATH_MAX 256
+
+/* Check if a cpu is present by the presence of the cpu information for it */
+static int blockdev_cpu_detected(unsigned lcore_id)
+{
+	char path[BDEV_CPU_PATH_MAX];
+	int len = snprintf(path, sizeof(path), BDEV_SYS_CPU_DIR
+		"/"BDEV_CORE_ID_FILE, lcore_id);
+	if (len <= 0 || (unsigned)len >= sizeof(path))
+		return 0;
+	if (access(path, F_OK) != 0)
+		return 0;
+
+	return 1;
+}
+
+static void *blockdev_rbd_thread_route(void *arg)
+{
+	unsigned i = 0;
+	int ret = 0;
+	/* set CPU affinity */
+	rte_cpuset_t cpuset;
+
+	unsigned num = sysconf(_SC_NPROCESSORS_CONF);
+	struct blockdev_rbd_io_channel *ch = (struct blockdev_rbd_io_channel *)arg;
+
+	CPU_ZERO(&cpuset);
+
+	for (i = 0; i < num; i++) {
+		if (blockdev_cpu_detected(i)) {
+			CPU_SET(i, &cpuset);
+		} else {
+			SPDK_WARNLOG("cpu core %d isn't online\n", i);
+		}
+	}
+
+	if (rte_thread_set_affinity(&cpuset) < 0) {
+		SPDK_NOTICELOG("cannot set affinity rbd_thread to all online cores\n");
+	}
+
+	ret = rbd_open(ch->io_ctx, ch->disk->rbd_name, &ch->image, NULL);
+	if (ret < 0) {
+		SPDK_ERRLOG("Failed to open specified rbd device\n");
+	}
+
+	return (void *)(long int)ret;
+}
+
+static int blockdev_rbd_thread_init(struct blockdev_rbd_io_channel *channel) {
+	pthread_t tid = 0;
+	void * ret_val = NULL;
+
+	int ret = pthread_create(&tid, NULL, (void *)blockdev_rbd_thread_route, channel);
+	if (ret != 0) {
+		rte_panic("Cannot create thread rbd_thread\n");
+		return -1;
+	}
+
+	ret = pthread_join(tid, &ret_val);
+	if (ret != 0) {
+		rte_panic("Thread rbd_thread join is fail\n");
+		return -1;
+	}
+
+	return (ret_val ? -1 : 0);
 }
 
 static int


### PR DESCRIPTION
…rder to void CPU resource competition.

Each rbd_open, will create nearly 10 rbd related threads, they are very CPU consuming, especially the thread "tp_librbd". In this case, we prefer to let rbd threads have the possibility to run on all cpu cores, not only the specified "reactorX" core. After testing, the performance has big improvement.