### PR TITLE
bdev: add members for SCSI sense information in spdk_bdev_io

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -6,14 +6,14 @@ library interface.  The *env* interface provides APIs for drivers
 to allocate physically contiguous and pinned memory, perform PCI
 operations (config cycles and mapping BARs), virtual to physical
 address translation and managing memory pools.  The *env* API is
-defined in `[include/spdk/env.h](include/spdk/env.h)`.
+defined in [include/spdk/env.h](include/spdk/env.h).
 
 SPDK includes a default implementation of the *env* library based
 on the Data Plane Development Kit ([DPDK](http://dpdk.org/)).
-This DPDK implementation can be found in `lib/env`.  DPDK is
-currently supported on Linux and FreeBSD only.
+This DPDK implementation can be found in `lib/env`.
 
-Users who want to use SPDK on other operating system, or in
+DPDK is currently supported on Linux and FreeBSD only.
+Users who want to use SPDK on other operating systems, or in
 userspace driver frameworks other than DPDK, will need to implement
 a new version of the *env* library.  The new implementation can be
 integrated into the SPDK build by updating the following line

--- a/PORTING.md
+++ b/PORTING.md
@@ -1,21 +1,22 @@
 SPDK Porting Guide
 ==================
 
-SPDK is ported to new environments by implementing the nvme_impl
-interface.  The nvme_impl interface provides APIs for the driver
+SPDK is ported to new environments by implementing the *env*
+library interface.  The *env* interface provides APIs for drivers
 to allocate physically contiguous and pinned memory, perform PCI
 operations (config cycles and mapping BARs), virtual to physical
-address translation and allocating per I/O data structures.
+address translation and managing memory pools.  The *env* API is
+defined in `[include/spdk/env.h](include/spdk/env.h)`.
 
-SPDK includes a default implementation of the nvme_impl API based
-on the Data Plane Development Kit ([DPDK](dpdk.org)).  This DPDK
-implementation can be found in lib/nvme/nvme_impl.h.  DPDK is
+SPDK includes a default implementation of the *env* library based
+on the Data Plane Development Kit ([DPDK](http://dpdk.org/)).
+This DPDK implementation can be found in `lib/env`.  DPDK is
 currently supported on Linux and FreeBSD only.
 
 Users who want to use SPDK on other operating system, or in
 userspace driver frameworks other than DPDK, will need to implement
-a new version of nvme_impl.h.  The new nvme_impl.h can be
+a new version of the *env* library.  The new implementation can be
 integrated into the SPDK build by updating the following line
 in CONFIG:
 
-    CONFIG_NVME_IMPL=nvme_impl.h
+    CONFIG_ENV?=$(SPDK_ROOT_DIR)/lib/env

--- a/app/iscsi_tgt/Makefile
+++ b/app/iscsi_tgt/Makefile
@@ -49,6 +49,7 @@ SPDK_LIBS = \
 	$(SPDK_ROOT_DIR)/lib/json/libspdk_json.a \
 	$(SPDK_ROOT_DIR)/lib/jsonrpc/libspdk_jsonrpc.a \
 	$(SPDK_ROOT_DIR)/lib/rpc/libspdk_rpc.a \
+	$(SPDK_ROOT_DIR)/lib/bdev/rpc/libspdk_bdev_rpc.a \
 	$(SPDK_ROOT_DIR)/lib/bdev/libspdk_bdev.a \
 	$(SPDK_ROOT_DIR)/lib/iscsi/libspdk_iscsi.a \
 	$(SPDK_ROOT_DIR)/lib/scsi/libspdk_scsi.a \

--- a/app/nvmf_tgt/Makefile
+++ b/app/nvmf_tgt/Makefile
@@ -54,6 +54,10 @@ SPDK_LIBS = \
 	$(SPDK_ROOT_DIR)/lib/rpc/libspdk_rpc.a \
 	$(SPDK_ROOT_DIR)/lib/jsonrpc/libspdk_jsonrpc.a \
 	$(SPDK_ROOT_DIR)/lib/json/libspdk_json.a \
+
+# These libraries do not expose any external API, only constructors,
+# so they must be linked specially to ensure they are not removed.
+SPDK_WHOLE_LIBS = \
 	$(SPDK_ROOT_DIR)/lib/event/rpc/libspdk_app_rpc.a \
 	$(SPDK_ROOT_DIR)/lib/log/rpc/libspdk_log_rpc.a \
 
@@ -61,6 +65,8 @@ LIBS += $(BLOCKDEV_MODULES_LINKER_ARGS) \
         $(COPY_MODULES_LINKER_ARGS)
 
 LIBS += $(SPDK_LIBS)
+
+LIBS += -Wl,--whole-archive $(SPDK_WHOLE_LIBS) -Wl,--no-whole-archive
 
 ifeq ($(CONFIG_RDMA),y)
 LIBS += -libverbs -lrdmacm
@@ -70,7 +76,7 @@ LIBS += $(ENV_LINKER_ARGS)
 
 all : $(APP)
 
-$(APP) : $(OBJS) $(SPDK_LIBS) $(BLOCKDEV_MODULES) $(LINKER_MODULES) $(ENV_LIBS)
+$(APP) : $(OBJS) $(SPDK_LIBS) $(SPDK_WHOLE_LIBS) $(BLOCKDEV_MODULES) $(LINKER_MODULES) $(ENV_LIBS)
 	$(LINK_C)
 
 clean :

--- a/app/nvmf_tgt/Makefile
+++ b/app/nvmf_tgt/Makefile
@@ -60,6 +60,7 @@ SPDK_LIBS = \
 SPDK_WHOLE_LIBS = \
 	$(SPDK_ROOT_DIR)/lib/event/rpc/libspdk_app_rpc.a \
 	$(SPDK_ROOT_DIR)/lib/log/rpc/libspdk_log_rpc.a \
+	$(SPDK_ROOT_DIR)/lib/bdev/rpc/libspdk_bdev_rpc.a \
 
 LIBS += $(BLOCKDEV_MODULES_LINKER_ARGS) \
         $(COPY_MODULES_LINKER_ARGS)

--- a/app/nvmf_tgt/conf.c
+++ b/app/nvmf_tgt/conf.c
@@ -366,19 +366,16 @@ attach_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr *ctr
 	  const struct spdk_nvme_ctrlr_opts *opts)
 {
 	struct spdk_nvmf_probe_ctx *ctx = cb_ctx;
-	uint16_t found_domain = spdk_pci_device_get_domain(dev);
-	uint8_t found_bus    = spdk_pci_device_get_bus(dev);
-	uint8_t found_dev    = spdk_pci_device_get_dev(dev);
-	uint8_t found_func   = spdk_pci_device_get_func(dev);
+	struct spdk_pci_addr pci_addr = spdk_pci_device_get_addr(dev);
 	int rc;
 	char path[MAX_STRING_LEN];
 	int numa_node = -1;
 
 	SPDK_NOTICELOG("Attaching NVMe device %p at %x:%x:%x.%x to subsystem %p\n",
-		       ctrlr, found_domain, found_bus, found_dev, found_func, ctx->subsystem);
+		       ctrlr, pci_addr.domain, pci_addr.bus, pci_addr.dev, pci_addr.func, ctx->subsystem);
 
 	snprintf(path, sizeof(path), "/sys/bus/pci/devices/%04x:%02x:%02x.%1u/numa_node",
-		 found_domain, found_bus, found_dev, found_func);
+		 pci_addr.domain, pci_addr.bus, pci_addr.dev, pci_addr.func);
 
 	numa_node = spdk_get_numa_node_value(path);
 	if (numa_node >= 0) {
@@ -391,7 +388,7 @@ attach_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr *ctr
 		}
 	}
 
-	rc = nvmf_subsystem_add_ctrlr(ctx->subsystem, ctrlr, dev);
+	rc = nvmf_subsystem_add_ctrlr(ctx->subsystem, ctrlr, &pci_addr);
 	if (rc < 0) {
 		SPDK_ERRLOG("Failed to add controller to subsystem\n");
 	}

--- a/app/nvmf_tgt/nvmf_rpc.c
+++ b/app/nvmf_tgt/nvmf_rpc.c
@@ -101,13 +101,12 @@ dump_nvmf_subsystem(struct spdk_json_write_ctx *w, struct nvmf_tgt_subsystem *tg
 	if (subsystem->subtype == SPDK_NVMF_SUBTYPE_NVME) {
 		if (subsystem->mode == NVMF_SUBSYSTEM_MODE_DIRECT) {
 			char pci_str[20];
-			struct spdk_pci_device *dev = subsystem->dev.direct.pci_dev;
 
 			snprintf(pci_str, sizeof(pci_str), "%04x:%02x:%02x.%x",
-				 spdk_pci_device_get_domain(dev),
-				 spdk_pci_device_get_bus(dev),
-				 spdk_pci_device_get_dev(dev),
-				 spdk_pci_device_get_func(dev));
+				 subsystem->dev.direct.pci_addr.domain,
+				 subsystem->dev.direct.pci_addr.bus,
+				 subsystem->dev.direct.pci_addr.dev,
+				 subsystem->dev.direct.pci_addr.func);
 
 			spdk_json_write_name(w, "pci_address");
 			spdk_json_write_string(w, pci_str);

--- a/doc/nvme/index.txt
+++ b/doc/nvme/index.txt
@@ -52,7 +52,6 @@ spdk_nvme_qpair_process_completions()   | \copybrief spdk_nvme_qpair_process_com
 
 \section nvme_key_concepts Key Concepts
 
-- \ref nvme_driver_integration
 - \ref nvme_initialization
 - \ref nvme_io_submission
 - \ref nvme_async_completion

--- a/etc/spdk/nvmf.conf.in
+++ b/etc/spdk/nvmf.conf.in
@@ -23,6 +23,13 @@
   # syslog facility
   LogFacility "local7"
 
+[Rpc]
+  # Defines whether to enable configuration via RPC.
+  # Default is disabled.  Note that the RPC interface is not
+  # authenticated, so users should be careful about enabling
+  # RPC in non-trusted environments.
+  Enable No
+
 # Users may change this section to create a different number or size of
 #  malloc LUNs.
 # This will generate 8 LUNs with a malloc-allocated backend.

--- a/examples/ioat/perf/perf.c
+++ b/examples/ioat/perf/perf.c
@@ -146,11 +146,10 @@ static bool
 probe_cb(void *cb_ctx, struct spdk_pci_device *pci_dev)
 {
 	printf(" Found matching device at %d:%d:%d "
-	       "vendor:0x%04x device:0x%04x\n   name:%s\n",
+	       "vendor:0x%04x device:0x%04x\n",
 	       spdk_pci_device_get_bus(pci_dev), spdk_pci_device_get_dev(pci_dev),
 	       spdk_pci_device_get_func(pci_dev),
-	       spdk_pci_device_get_vendor_id(pci_dev), spdk_pci_device_get_device_id(pci_dev),
-	       spdk_pci_device_get_device_name(pci_dev));
+	       spdk_pci_device_get_vendor_id(pci_dev), spdk_pci_device_get_device_id(pci_dev));
 
 	return true;
 }

--- a/examples/ioat/verify/verify.c
+++ b/examples/ioat/verify/verify.c
@@ -202,11 +202,10 @@ static bool
 probe_cb(void *cb_ctx, struct spdk_pci_device *pci_dev)
 {
 	printf(" Found matching device at %d:%d:%d "
-	       "vendor:0x%04x device:0x%04x\n   name:%s\n",
+	       "vendor:0x%04x device:0x%04x\n",
 	       spdk_pci_device_get_bus(pci_dev), spdk_pci_device_get_dev(pci_dev),
 	       spdk_pci_device_get_func(pci_dev),
-	       spdk_pci_device_get_vendor_id(pci_dev), spdk_pci_device_get_device_id(pci_dev),
-	       spdk_pci_device_get_device_name(pci_dev));
+	       spdk_pci_device_get_vendor_id(pci_dev), spdk_pci_device_get_device_id(pci_dev));
 
 	return true;
 }

--- a/examples/nvme/arbitration/arbitration.c
+++ b/examples/nvme/arbitration/arbitration.c
@@ -865,29 +865,30 @@ register_workers(void)
 }
 
 static bool
-probe_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr_opts *opts)
+probe_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	 struct spdk_nvme_ctrlr_opts *opts)
 {
 	/* Update with user specified arbitration configuration */
 	opts->arb_mechanism = g_arbitration.arbitration_mechanism;
 
 	printf("Attaching to %04x:%02x:%02x.%02x\n",
-	       spdk_pci_device_get_domain(dev),
-	       spdk_pci_device_get_bus(dev),
-	       spdk_pci_device_get_dev(dev),
-	       spdk_pci_device_get_func(dev));
+	       probe_info->pci_addr.domain,
+	       probe_info->pci_addr.bus,
+	       probe_info->pci_addr.dev,
+	       probe_info->pci_addr.func);
 
 	return true;
 }
 
 static void
-attach_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr *ctrlr,
-	  const struct spdk_nvme_ctrlr_opts *opts)
+attach_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	  struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *opts)
 {
 	printf("Attached to %04x:%02x:%02x.%02x\n",
-	       spdk_pci_device_get_domain(dev),
-	       spdk_pci_device_get_bus(dev),
-	       spdk_pci_device_get_dev(dev),
-	       spdk_pci_device_get_func(dev));
+	       probe_info->pci_addr.domain,
+	       probe_info->pci_addr.bus,
+	       probe_info->pci_addr.dev,
+	       probe_info->pci_addr.func);
 
 	/* Update with actual arbitration configuration in use */
 	g_arbitration.arbitration_mechanism = opts->arb_mechanism;

--- a/examples/nvme/hello_world/hello_world.c
+++ b/examples/nvme/hello_world/hello_world.c
@@ -238,20 +238,21 @@ hello_world(void)
 }
 
 static bool
-probe_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr_opts *opts)
+probe_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	 struct spdk_nvme_ctrlr_opts *opts)
 {
 	printf("Attaching to %04x:%02x:%02x.%02x\n",
-	       spdk_pci_device_get_domain(dev),
-	       spdk_pci_device_get_bus(dev),
-	       spdk_pci_device_get_dev(dev),
-	       spdk_pci_device_get_func(dev));
+	       probe_info->pci_addr.domain,
+	       probe_info->pci_addr.bus,
+	       probe_info->pci_addr.dev,
+	       probe_info->pci_addr.func);
 
 	return true;
 }
 
 static void
-attach_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr *ctrlr,
-	  const struct spdk_nvme_ctrlr_opts *opts)
+attach_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	  struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *opts)
 {
 	int nsid, num_ns;
 	struct ctrlr_entry *entry;
@@ -264,10 +265,10 @@ attach_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr *ctr
 	}
 
 	printf("Attached to %04x:%02x:%02x.%02x\n",
-	       spdk_pci_device_get_domain(dev),
-	       spdk_pci_device_get_bus(dev),
-	       spdk_pci_device_get_dev(dev),
-	       spdk_pci_device_get_func(dev));
+	       probe_info->pci_addr.domain,
+	       probe_info->pci_addr.bus,
+	       probe_info->pci_addr.dev,
+	       probe_info->pci_addr.func);
 
 	snprintf(entry->name, sizeof(entry->name), "%-20.20s (%-20.20s)", cdata->mn, cdata->sn);
 

--- a/examples/nvme/identify/identify.c
+++ b/examples/nvme/identify/identify.c
@@ -383,7 +383,7 @@ print_namespace(struct spdk_nvme_ns *ns)
 }
 
 static void
-print_controller(struct spdk_nvme_ctrlr *ctrlr, struct spdk_pci_device *pci_dev)
+print_controller(struct spdk_nvme_ctrlr *ctrlr, const struct spdk_pci_addr *pci_addr)
 {
 	const struct spdk_nvme_ctrlr_data	*cdata;
 	union spdk_nvme_cap_register		cap;
@@ -402,8 +402,7 @@ print_controller(struct spdk_nvme_ctrlr *ctrlr, struct spdk_pci_device *pci_dev)
 
 	printf("=====================================================\n");
 	printf("NVMe Controller at PCI bus %d, device %d, function %d\n",
-	       spdk_pci_device_get_bus(pci_dev), spdk_pci_device_get_dev(pci_dev),
-	       spdk_pci_device_get_func(pci_dev));
+	       pci_addr->bus, pci_addr->dev, pci_addr->func);
 	printf("=====================================================\n");
 
 	if (g_hex_dump) {
@@ -872,16 +871,17 @@ parse_args(int argc, char **argv)
 }
 
 static bool
-probe_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr_opts *opts)
+probe_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	 struct spdk_nvme_ctrlr_opts *opts)
 {
 	return true;
 }
 
 static void
-attach_cb(void *cb_ctx, struct spdk_pci_device *pci_dev, struct spdk_nvme_ctrlr *ctrlr,
-	  const struct spdk_nvme_ctrlr_opts *opts)
+attach_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	  struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *opts)
 {
-	print_controller(ctrlr, pci_dev);
+	print_controller(ctrlr, &probe_info->pci_addr);
 	spdk_nvme_detach(ctrlr);
 }
 

--- a/examples/nvme/nvme_manage/nvme_manage.c
+++ b/examples/nvme/nvme_manage/nvme_manage.c
@@ -299,10 +299,6 @@ display_controller_list(void)
 static struct dev *
 get_controller(void)
 {
-	unsigned int				domain;
-	unsigned int				bus;
-	unsigned int				devid;
-	unsigned int				function;
 	struct spdk_pci_addr			pci_addr;
 	char					address[64];
 	char					*p;
@@ -327,23 +323,9 @@ get_controller(void)
 		p++;
 	}
 
-	if (sscanf(p, "%x:%x:%x.%x", &domain, &bus, &devid, &function) == 4) {
-		/* Matched a full address - all variables are initialized */
-	} else if (sscanf(p, "%x:%x:%x", &domain, &bus, &devid) == 3) {
-		function = 0;
-	} else if (sscanf(p, "%x:%x.%x", &bus, &devid, &function) == 3) {
-		domain = 0;
-	} else if (sscanf(p, "%x:%x", &bus, &devid) == 2) {
-		domain = 0;
-		function = 0;
-	} else {
+	if (spdk_pci_addr_parse(&pci_addr, p) < 0) {
 		return NULL;
 	}
-
-	pci_addr.domain = domain;
-	pci_addr.bus = bus;
-	pci_addr.dev = devid;
-	pci_addr.func = function;
 
 	foreach_dev(iter) {
 		struct spdk_pci_addr iter_addr = spdk_pci_device_get_addr(iter->pci_dev);

--- a/examples/nvme/nvme_manage/nvme_manage.c
+++ b/examples/nvme/nvme_manage/nvme_manage.c
@@ -51,7 +51,7 @@
 #define MAX_DEVS 64
 
 struct dev {
-	struct spdk_pci_device			*pci_dev;
+	struct spdk_pci_addr			pci_addr;
 	struct spdk_nvme_ctrlr 			*ctrlr;
 	const struct spdk_nvme_ctrlr_data	*cdata;
 	struct spdk_nvme_ns_data		*common_ns_data;
@@ -73,14 +73,13 @@ static int
 cmp_devs(const void *ap, const void *bp)
 {
 	const struct dev *a = ap, *b = bp;
-	struct spdk_pci_addr a1 = spdk_pci_device_get_addr(a->pci_dev);
-	struct spdk_pci_addr a2 = spdk_pci_device_get_addr(b->pci_dev);
 
-	return spdk_pci_addr_compare(&a1, &a2);
+	return spdk_pci_addr_compare(&a->pci_addr, &b->pci_addr);
 }
 
 static bool
-probe_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr_opts *opts)
+probe_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	 struct spdk_nvme_ctrlr_opts *opts)
 {
 	return true;
 }
@@ -100,15 +99,15 @@ identify_common_ns_cb(void *cb_arg, const struct spdk_nvme_cpl *cpl)
 }
 
 static void
-attach_cb(void *cb_ctx, struct spdk_pci_device *pci_dev, struct spdk_nvme_ctrlr *ctrlr,
-	  const struct spdk_nvme_ctrlr_opts *opts)
+attach_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	  struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *opts)
 {
 	struct dev *dev;
 	struct spdk_nvme_cmd cmd;
 
 	/* add to dev list */
 	dev = &devs[num_devs++];
-	dev->pci_dev = pci_dev;
+	dev->pci_addr = probe_info->pci_addr;
 	dev->ctrlr = ctrlr;
 
 	/* Retrieve controller data */
@@ -244,8 +243,7 @@ display_controller(struct dev *dev, int model)
 
 	if (model == CONTROLLER_DISPLAY_SIMPLISTIC) {
 		printf("%04x:%02x:%02x.%02x ",
-		       spdk_pci_device_get_domain(dev->pci_dev), spdk_pci_device_get_bus(dev->pci_dev),
-		       spdk_pci_device_get_dev(dev->pci_dev), spdk_pci_device_get_func(dev->pci_dev));
+		       dev->pci_addr.domain, dev->pci_addr.bus, dev->pci_addr.dev, dev->pci_addr.func);
 		printf("%-40.40s %-20.20s ",
 		       cdata->mn, cdata->sn);
 		printf("%5d ", cdata->cntlid);
@@ -255,8 +253,7 @@ display_controller(struct dev *dev, int model)
 
 	printf("=====================================================\n");
 	printf("NVMe Controller:	%04x:%02x:%02x.%02x\n",
-	       spdk_pci_device_get_domain(dev->pci_dev), spdk_pci_device_get_bus(dev->pci_dev),
-	       spdk_pci_device_get_dev(dev->pci_dev), spdk_pci_device_get_func(dev->pci_dev));
+	       dev->pci_addr.domain, dev->pci_addr.bus, dev->pci_addr.dev, dev->pci_addr.func);
 	printf("============================\n");
 	printf("Controller Capabilities/Features\n");
 	printf("Controller ID:		%d\n", cdata->cntlid);
@@ -328,9 +325,7 @@ get_controller(void)
 	}
 
 	foreach_dev(iter) {
-		struct spdk_pci_addr iter_addr = spdk_pci_device_get_addr(iter->pci_dev);
-
-		if (spdk_pci_addr_compare(&pci_addr, &iter_addr) == 0) {
+		if (spdk_pci_addr_compare(&pci_addr, &iter->pci_addr) == 0) {
 			return iter;
 		}
 	}

--- a/examples/nvme/perf/perf.c
+++ b/examples/nvme/perf/perf.c
@@ -962,26 +962,27 @@ unregister_workers(void)
 }
 
 static bool
-probe_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr_opts *opts)
+probe_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	 struct spdk_nvme_ctrlr_opts *opts)
 {
 	printf("Attaching to %04x:%02x:%02x.%02x\n",
-	       spdk_pci_device_get_domain(dev),
-	       spdk_pci_device_get_bus(dev),
-	       spdk_pci_device_get_dev(dev),
-	       spdk_pci_device_get_func(dev));
+	       probe_info->pci_addr.domain,
+	       probe_info->pci_addr.bus,
+	       probe_info->pci_addr.dev,
+	       probe_info->pci_addr.func);
 
 	return true;
 }
 
 static void
-attach_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr *ctrlr,
-	  const struct spdk_nvme_ctrlr_opts *opts)
+attach_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	  struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *opts)
 {
 	printf("Attached to %04x:%02x:%02x.%02x\n",
-	       spdk_pci_device_get_domain(dev),
-	       spdk_pci_device_get_bus(dev),
-	       spdk_pci_device_get_dev(dev),
-	       spdk_pci_device_get_func(dev));
+	       probe_info->pci_addr.domain,
+	       probe_info->pci_addr.bus,
+	       probe_info->pci_addr.dev,
+	       probe_info->pci_addr.func);
 
 	register_ctrlr(ctrlr);
 }

--- a/include/spdk/bdev.h
+++ b/include/spdk/bdev.h
@@ -137,6 +137,7 @@ struct spdk_bdev_fn_table {
 
 /** Blockdev I/O completion status */
 enum spdk_bdev_io_status {
+	SPDK_BDEV_IO_STATUS_SCSI_ERROR = -3,
 	SPDK_BDEV_IO_STATUS_NVME_ERROR = -2,
 	SPDK_BDEV_IO_STATUS_FAILED = -1,
 	SPDK_BDEV_IO_STATUS_PENDING = 0,
@@ -252,6 +253,17 @@ struct spdk_bdev_io {
 			/** NVMe status code */
 			int sc;
 		} nvme;
+		/** Only valid when status is SPDK_BDEV_IO_STATUS_SCSI_ERROR */
+		struct {
+			/** SCSI status code */
+			int sc;
+			/** SCSI sense key */
+			int sk;
+			/** SCSI additional sense code */
+			int asc;
+			/** SCSI additional sense code qualifier */
+			int ascq;
+		} scsi;
 	} error;
 
 	/** User function that will be called when this completes */
@@ -321,4 +333,6 @@ int spdk_bdev_free_io(struct spdk_bdev_io *bdev_io);
 int spdk_bdev_reset(struct spdk_bdev *bdev, enum spdk_bdev_reset_type,
 		    spdk_bdev_io_completion_cb cb, void *cb_arg);
 struct spdk_io_channel *spdk_bdev_get_io_channel(struct spdk_bdev *bdev, uint32_t priority);
+
+void spdk_bdev_set_scsi_sense(struct spdk_bdev_io *bdev_io, int sk, int asc, int ascq);
 #endif /* SPDK_BDEV_H_ */

--- a/include/spdk/bdev.h
+++ b/include/spdk/bdev.h
@@ -256,13 +256,13 @@ struct spdk_bdev_io {
 		/** Only valid when status is SPDK_BDEV_IO_STATUS_SCSI_ERROR */
 		struct {
 			/** SCSI status code */
-			int sc;
+			enum spdk_scsi_status sc;
 			/** SCSI sense key */
-			int sk;
+			enum spdk_scsi_sense sk;
 			/** SCSI additional sense code */
-			int asc;
+			uint8_t asc;
 			/** SCSI additional sense code qualifier */
-			int ascq;
+			uint8_t ascq;
 		} scsi;
 	} error;
 
@@ -333,6 +333,6 @@ int spdk_bdev_free_io(struct spdk_bdev_io *bdev_io);
 int spdk_bdev_reset(struct spdk_bdev *bdev, enum spdk_bdev_reset_type,
 		    spdk_bdev_io_completion_cb cb, void *cb_arg);
 struct spdk_io_channel *spdk_bdev_get_io_channel(struct spdk_bdev *bdev, uint32_t priority);
-
-void spdk_bdev_set_scsi_sense(struct spdk_bdev_io *bdev_io, int sk, int asc, int ascq);
+void spdk_bdev_io_set_scsi_error(struct spdk_bdev_io *bdev_io, enum spdk_scsi_status sc,
+				 enum spdk_scsi_sense sk, uint8_t asc, uint8_t ascq);
 #endif /* SPDK_BDEV_H_ */

--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -198,7 +198,6 @@ uint16_t spdk_pci_device_get_subdevice_id(struct spdk_pci_device *dev);
 struct spdk_pci_id spdk_pci_device_get_id(struct spdk_pci_device *dev);
 
 uint32_t spdk_pci_device_get_class(struct spdk_pci_device *dev);
-const char *spdk_pci_device_get_device_name(struct spdk_pci_device *dev);
 int spdk_pci_device_get_serial_number(struct spdk_pci_device *dev, char *sn, size_t len);
 int spdk_pci_device_claim(const struct spdk_pci_addr *pci_addr);
 

--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -159,6 +159,13 @@ struct spdk_pci_addr {
 	uint8_t				func;
 };
 
+struct spdk_pci_id {
+	uint16_t	vendor_id;
+	uint16_t	device_id;
+	uint16_t	subvendor_id;
+	uint16_t	subdevice_id;
+};
+
 typedef int (*spdk_pci_enum_cb)(void *enum_ctx, struct spdk_pci_device *pci_dev);
 
 int spdk_pci_enumerate(enum spdk_pci_device_type type,
@@ -180,6 +187,9 @@ uint16_t spdk_pci_device_get_vendor_id(struct spdk_pci_device *dev);
 uint16_t spdk_pci_device_get_device_id(struct spdk_pci_device *dev);
 uint16_t spdk_pci_device_get_subvendor_id(struct spdk_pci_device *dev);
 uint16_t spdk_pci_device_get_subdevice_id(struct spdk_pci_device *dev);
+
+struct spdk_pci_id spdk_pci_device_get_id(struct spdk_pci_device *dev);
+
 uint32_t spdk_pci_device_get_class(struct spdk_pci_device *dev);
 const char *spdk_pci_device_get_device_name(struct spdk_pci_device *dev);
 int spdk_pci_device_get_serial_number(struct spdk_pci_device *dev, char *sn, size_t len);

--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -51,6 +51,13 @@ struct spdk_pci_device;
 
 /**
  * Allocate a pinned, physically contiguous memory buffer with the
+ *   given size and alignment.
+ */
+void *
+spdk_malloc(size_t size, size_t align, uint64_t *phys_addr);
+
+/**
+ * Allocate a pinned, physically contiguous memory buffer with the
  *   given size and alignment. The buffer will be zeroed.
  */
 void *

--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -209,6 +209,16 @@ int spdk_pci_device_cfg_write32(struct spdk_pci_device *dev, uint32_t value, uin
  */
 int spdk_pci_addr_compare(const struct spdk_pci_addr *a1, const struct spdk_pci_addr *a2);
 
+/**
+ * Convert a string representation of a PCI address into a struct spdk_pci_addr.
+ *
+ * \param addr PCI adddress output on success
+ * \param bdf PCI address in domain:bus:device.function format
+ *
+ * \return 0 on success, or a negated errno value on failure.
+ */
+int spdk_pci_addr_parse(struct spdk_pci_addr *addr, const char *bdf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -193,7 +193,7 @@ struct spdk_pci_id spdk_pci_device_get_id(struct spdk_pci_device *dev);
 uint32_t spdk_pci_device_get_class(struct spdk_pci_device *dev);
 const char *spdk_pci_device_get_device_name(struct spdk_pci_device *dev);
 int spdk_pci_device_get_serial_number(struct spdk_pci_device *dev, char *sn, size_t len);
-int spdk_pci_device_claim(struct spdk_pci_device *dev);
+int spdk_pci_device_claim(const struct spdk_pci_addr *pci_addr);
 
 int spdk_pci_device_cfg_read8(struct spdk_pci_device *dev, uint8_t *value, uint32_t offset);
 int spdk_pci_device_cfg_write8(struct spdk_pci_device *dev, uint8_t value, uint32_t offset);

--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -173,6 +173,9 @@ uint16_t spdk_pci_device_get_domain(struct spdk_pci_device *dev);
 uint8_t spdk_pci_device_get_bus(struct spdk_pci_device *dev);
 uint8_t spdk_pci_device_get_dev(struct spdk_pci_device *dev);
 uint8_t spdk_pci_device_get_func(struct spdk_pci_device *dev);
+
+struct spdk_pci_addr spdk_pci_device_get_addr(struct spdk_pci_device *dev);
+
 uint16_t spdk_pci_device_get_vendor_id(struct spdk_pci_device *dev);
 uint16_t spdk_pci_device_get_device_id(struct spdk_pci_device *dev);
 uint16_t spdk_pci_device_get_subvendor_id(struct spdk_pci_device *dev);
@@ -189,7 +192,12 @@ int spdk_pci_device_cfg_write16(struct spdk_pci_device *dev, uint16_t value, uin
 int spdk_pci_device_cfg_read32(struct spdk_pci_device *dev, uint32_t *value, uint32_t offset);
 int spdk_pci_device_cfg_write32(struct spdk_pci_device *dev, uint32_t value, uint32_t offset);
 
-bool spdk_pci_device_compare_addr(struct spdk_pci_device *dev, struct spdk_pci_addr *addr);
+/**
+ * Compare two PCI addresses.
+ *
+ * \return 0 if a1 == a2, less than 0 if a1 < a2, greater than 0 if a1 > a2
+ */
+int spdk_pci_addr_compare(const struct spdk_pci_addr *a1, const struct spdk_pci_addr *a2);
 
 #ifdef __cplusplus
 }

--- a/include/spdk/json.h
+++ b/include/spdk/json.h
@@ -196,6 +196,8 @@ int spdk_json_write_null(struct spdk_json_write_ctx *w);
 int spdk_json_write_bool(struct spdk_json_write_ctx *w, bool val);
 int spdk_json_write_int32(struct spdk_json_write_ctx *w, int32_t val);
 int spdk_json_write_uint32(struct spdk_json_write_ctx *w, uint32_t val);
+int spdk_json_write_int64(struct spdk_json_write_ctx *w, int64_t val);
+int spdk_json_write_uint64(struct spdk_json_write_ctx *w, uint64_t val);
 int spdk_json_write_string(struct spdk_json_write_ctx *w, const char *val);
 int spdk_json_write_string_raw(struct spdk_json_write_ctx *w, const char *val, size_t len);
 int spdk_json_write_array_begin(struct spdk_json_write_ctx *w);

--- a/include/spdk/json.h
+++ b/include/spdk/json.h
@@ -185,6 +185,8 @@ int spdk_json_number_to_uint32(const struct spdk_json_val *val, uint32_t *num);
 
 struct spdk_json_write_ctx;
 
+#define SPDK_JSON_WRITE_FLAG_FORMATTED	0x00000001
+
 typedef int (*spdk_json_write_cb)(void *cb_ctx, const void *data, size_t size);
 
 struct spdk_json_write_ctx *spdk_json_write_begin(spdk_json_write_cb write_cb, void *cb_ctx,

--- a/include/spdk/nvme.h
+++ b/include/spdk/nvme.h
@@ -89,6 +89,25 @@ struct spdk_nvme_ctrlr_opts {
 };
 
 /**
+ * NVMe controller information provided during spdk_nvme_probe().
+ */
+struct spdk_nvme_probe_info {
+	/**
+	 * PCI address.
+	 *
+	 * If not available, each field will be filled with all 0xFs.
+	 */
+	struct spdk_pci_addr pci_addr;
+
+	/**
+	 * PCI device ID.
+	 *
+	 * If not available, each field will be filled with all 0xFs.
+	 */
+	struct spdk_pci_id pci_id;
+};
+
+/**
  * Callback for spdk_nvme_probe() enumeration.
  *
  * \param opts NVMe controller initialization options.  This structure will be populated with the
@@ -97,7 +116,7 @@ struct spdk_nvme_ctrlr_opts {
  * provided during the attach callback.
  * \return true to attach to this device.
  */
-typedef bool (*spdk_nvme_probe_cb)(void *cb_ctx, struct spdk_pci_device *pci_dev,
+typedef bool (*spdk_nvme_probe_cb)(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
 				   struct spdk_nvme_ctrlr_opts *opts);
 
 /**
@@ -106,7 +125,7 @@ typedef bool (*spdk_nvme_probe_cb)(void *cb_ctx, struct spdk_pci_device *pci_dev
  * \param opts NVMe controller initialization options that were actually used.  Options may differ
  * from the requested options from the probe call depending on what the controller supports.
  */
-typedef void (*spdk_nvme_attach_cb)(void *cb_ctx, struct spdk_pci_device *pci_dev,
+typedef void (*spdk_nvme_attach_cb)(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
 				    struct spdk_nvme_ctrlr *ctrlr,
 				    const struct spdk_nvme_ctrlr_opts *opts);
 

--- a/include/spdk/nvme.h
+++ b/include/spdk/nvme.h
@@ -77,6 +77,15 @@ struct spdk_nvme_ctrlr_opts {
 	 * Type of arbitration mechanism
 	 */
 	enum spdk_nvme_cc_ams arb_mechanism;
+	/**
+	 * Keep alive timeout in milliseconds (0 = disabled).
+	 *
+	 * The NVMe library will set the Keep Alive Timer feature to this value and automatically
+	 * send Keep Alive commands as needed.  The library user must call
+	 * spdk_nvme_ctrlr_process_admin_completions() periodically to ensure Keep Alive commands
+	 * are sent.
+	 */
+	uint32_t keep_alive_timeout_ms;
 };
 
 /**

--- a/include/spdk/nvmf.h
+++ b/include/spdk/nvmf.h
@@ -40,6 +40,7 @@
 
 #include <stdint.h>
 
+#include "spdk/env.h"
 #include "spdk/nvmf_spec.h"
 #include "spdk/queue.h"
 
@@ -65,7 +66,6 @@ struct spdk_nvme_ctrlr;
 struct spdk_nvmf_transport;
 struct spdk_nvmf_request;
 struct spdk_nvmf_conn;
-struct spdk_pci_device;
 
 typedef void (*spdk_nvmf_subsystem_connect_fn)(void *cb_ctx, struct spdk_nvmf_request *req);
 typedef void (*spdk_nvmf_subsystem_disconnect_fn)(void *cb_ctx, struct spdk_nvmf_conn *conn);
@@ -130,7 +130,7 @@ struct spdk_nvmf_subsystem {
 		struct {
 			struct spdk_nvme_ctrlr *ctrlr;
 			struct spdk_nvme_qpair *io_qpair;
-			struct spdk_pci_device *pci_dev;
+			struct spdk_pci_addr pci_addr;
 		} direct;
 
 		struct {
@@ -183,7 +183,7 @@ spdk_nvmf_subsystem_add_host(struct spdk_nvmf_subsystem *subsystem,
 
 int
 nvmf_subsystem_add_ctrlr(struct spdk_nvmf_subsystem *subsystem,
-			 struct spdk_nvme_ctrlr *ctrlr, struct spdk_pci_device *dev);
+			 struct spdk_nvme_ctrlr *ctrlr, const struct spdk_pci_addr *pci_addr);
 
 void spdk_nvmf_subsystem_poll(struct spdk_nvmf_subsystem *subsystem);
 

--- a/lib/bdev/aio/blockdev_aio.c
+++ b/lib/bdev/aio/blockdev_aio.c
@@ -339,7 +339,7 @@ static void aio_free_disk(struct file_disk *fdisk)
 	free(fdisk);
 }
 
-struct file_disk *
+struct spdk_bdev *
 create_aio_disk(char *fname)
 {
 	struct file_disk *fdisk;
@@ -375,7 +375,7 @@ create_aio_disk(char *fname)
 	spdk_io_device_register(&fdisk->disk, blockdev_aio_create_cb, blockdev_aio_destroy_cb,
 				sizeof(struct blockdev_aio_io_channel));
 	spdk_bdev_register(&fdisk->disk);
-	return fdisk;
+	return &fdisk->disk;
 
 error_return:
 	blockdev_aio_close(fdisk);
@@ -385,7 +385,7 @@ error_return:
 
 static int blockdev_aio_initialize(void)
 {
-	struct file_disk *fdisk;
+	struct spdk_bdev *bdev;
 	int i;
 	const char *val = NULL;
 	char *file;
@@ -410,9 +410,9 @@ static int blockdev_aio_initialize(void)
 				return -1;
 			}
 
-			fdisk = create_aio_disk(file);
+			bdev = create_aio_disk(file);
 
-			if (fdisk == NULL && !skip_missing) {
+			if (bdev == NULL && !skip_missing) {
 				return -1;
 			}
 		}

--- a/lib/bdev/aio/blockdev_aio.h
+++ b/lib/bdev/aio/blockdev_aio.h
@@ -69,6 +69,6 @@ struct file_disk {
 	TAILQ_HEAD(, blockdev_aio_task) sync_completion_list;
 };
 
-struct file_disk *create_aio_disk(char *fname);
+struct spdk_bdev *create_aio_disk(char *fname);
 
 #endif // SPDK_BLOCKDEV_AIO_H

--- a/lib/bdev/aio/blockdev_aio_rpc.c
+++ b/lib/bdev/aio/blockdev_aio_rpc.c
@@ -56,6 +56,7 @@ spdk_rpc_construct_aio_bdev(struct spdk_jsonrpc_server_conn *conn,
 {
 	struct rpc_construct_aio req = {};
 	struct spdk_json_write_ctx *w;
+	struct spdk_bdev *bdev;
 
 	if (spdk_json_decode_object(params, rpc_construct_aio_decoders,
 				    sizeof(rpc_construct_aio_decoders) / sizeof(*rpc_construct_aio_decoders),
@@ -64,7 +65,8 @@ spdk_rpc_construct_aio_bdev(struct spdk_jsonrpc_server_conn *conn,
 		goto invalid;
 	}
 
-	if (create_aio_disk(req.fname) == NULL) {
+	bdev = create_aio_disk(req.fname);
+	if (bdev == NULL) {
 		goto invalid;
 	}
 
@@ -75,7 +77,9 @@ spdk_rpc_construct_aio_bdev(struct spdk_jsonrpc_server_conn *conn,
 	}
 
 	w = spdk_jsonrpc_begin_result(conn, id);
-	spdk_json_write_bool(w, true);
+	spdk_json_write_array_begin(w);
+	spdk_json_write_string(w, bdev->name);
+	spdk_json_write_array_end(w);
 	spdk_jsonrpc_end_result(conn, w);
 	return;
 

--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -837,10 +837,11 @@ spdk_bdev_io_complete(struct spdk_bdev_io *bdev_io, enum spdk_bdev_io_status sta
 }
 
 void
-spdk_bdev_set_scsi_sense(struct spdk_bdev_io *bdev_io, int sk, int asc, int ascq)
+spdk_bdev_io_set_scsi_error(struct spdk_bdev_io *bdev_io, enum spdk_scsi_status sc,
+			    enum spdk_scsi_sense sk, uint8_t asc, uint8_t ascq)
 {
 	bdev_io->status = SPDK_BDEV_IO_STATUS_SCSI_ERROR;
-	bdev_io->error.scsi.sc = SPDK_SCSI_STATUS_CHECK_CONDITION;
+	bdev_io->error.scsi.sc = sc;
 	bdev_io->error.scsi.sk = sk;
 	bdev_io->error.scsi.asc = asc;
 	bdev_io->error.scsi.ascq = ascq;

--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -837,6 +837,16 @@ spdk_bdev_io_complete(struct spdk_bdev_io *bdev_io, enum spdk_bdev_io_status sta
 }
 
 void
+spdk_bdev_set_scsi_sense(struct spdk_bdev_io *bdev_io, int sk, int asc, int ascq)
+{
+	bdev_io->status = SPDK_BDEV_IO_STATUS_SCSI_ERROR;
+	bdev_io->error.scsi.sc = SPDK_SCSI_STATUS_CHECK_CONDITION;
+	bdev_io->error.scsi.sk = sk;
+	bdev_io->error.scsi.asc = asc;
+	bdev_io->error.scsi.ascq = ascq;
+}
+
+void
 spdk_bdev_register(struct spdk_bdev *bdev)
 {
 	/* initialize the reset generation value to zero */

--- a/lib/bdev/malloc/blockdev_malloc.c
+++ b/lib/bdev/malloc/blockdev_malloc.c
@@ -364,7 +364,7 @@ static const struct spdk_bdev_fn_table malloc_fn_table = {
 	.get_io_channel		= blockdev_malloc_get_io_channel,
 };
 
-struct malloc_disk *create_malloc_disk(uint64_t num_blocks, uint32_t block_size)
+struct spdk_bdev *create_malloc_disk(uint64_t num_blocks, uint32_t block_size)
 {
 	struct malloc_disk	*mdisk;
 
@@ -415,7 +415,7 @@ struct malloc_disk *create_malloc_disk(uint64_t num_blocks, uint32_t block_size)
 	mdisk->next = g_malloc_disk_head;
 	g_malloc_disk_head = mdisk;
 
-	return mdisk;
+	return &mdisk->disk;
 }
 
 static void free_malloc_disk(struct malloc_disk *mdisk)
@@ -429,7 +429,7 @@ static int blockdev_malloc_initialize(void)
 	struct spdk_conf_section *sp = spdk_conf_find_section(NULL, "Malloc");
 	int NumberOfLuns, LunSizeInMB, BlockSize, i;
 	uint64_t size;
-	struct malloc_disk *mdisk;
+	struct spdk_bdev *bdev;
 
 	if (sp != NULL) {
 		NumberOfLuns = spdk_conf_section_get_intval(sp, "NumberOfLuns");
@@ -445,8 +445,8 @@ static int blockdev_malloc_initialize(void)
 		}
 		size = (uint64_t)LunSizeInMB * 1024 * 1024;
 		for (i = 0; i < NumberOfLuns; i++) {
-			mdisk = create_malloc_disk(size / BlockSize, BlockSize);
-			if (mdisk == NULL) {
+			bdev = create_malloc_disk(size / BlockSize, BlockSize);
+			if (bdev == NULL) {
 				SPDK_ERRLOG("Could not create malloc disk\n");
 				return EINVAL;
 			}

--- a/lib/bdev/malloc/blockdev_malloc.h
+++ b/lib/bdev/malloc/blockdev_malloc.h
@@ -36,8 +36,8 @@
 
 #include <stdint.h>
 
-struct malloc_disk;
+#include "spdk/bdev.h"
 
-struct malloc_disk *create_malloc_disk(uint64_t num_blocks, uint32_t block_size);
+struct spdk_bdev *create_malloc_disk(uint64_t num_blocks, uint32_t block_size);
 
 #endif /* SPDK_BLOCKDEV_MALLOC_H */

--- a/lib/bdev/malloc/blockdev_malloc_rpc.c
+++ b/lib/bdev/malloc/blockdev_malloc_rpc.c
@@ -52,6 +52,7 @@ spdk_rpc_construct_malloc_bdev(struct spdk_jsonrpc_server_conn *conn,
 {
 	struct rpc_construct_malloc req = {};
 	struct spdk_json_write_ctx *w;
+	struct spdk_bdev *bdev;
 
 	if (spdk_json_decode_object(params, rpc_construct_malloc_decoders,
 				    sizeof(rpc_construct_malloc_decoders) / sizeof(*rpc_construct_malloc_decoders),
@@ -60,7 +61,8 @@ spdk_rpc_construct_malloc_bdev(struct spdk_jsonrpc_server_conn *conn,
 		goto invalid;
 	}
 
-	if (create_malloc_disk(req.num_blocks, req.block_size) == NULL) {
+	bdev = create_malloc_disk(req.num_blocks, req.block_size);
+	if (bdev == NULL) {
 		goto invalid;
 	}
 
@@ -69,7 +71,9 @@ spdk_rpc_construct_malloc_bdev(struct spdk_jsonrpc_server_conn *conn,
 	}
 
 	w = spdk_jsonrpc_begin_result(conn, id);
-	spdk_json_write_bool(w, true);
+	spdk_json_write_array_begin(w);
+	spdk_json_write_string(w, bdev->name);
+	spdk_json_write_array_end(w);
 	spdk_jsonrpc_end_result(conn, w);
 	return;
 

--- a/lib/bdev/nvme/blockdev_nvme.c
+++ b/lib/bdev/nvme/blockdev_nvme.c
@@ -453,7 +453,7 @@ nvme_library_init(void)
 {
 	struct spdk_conf_section *sp;
 	const char *val;
-	int i, rc;
+	int i;
 	struct nvme_probe_ctx probe_ctx;
 
 	sp = spdk_conf_find_section(NULL, "Nvme");
@@ -496,23 +496,15 @@ nvme_library_init(void)
 
 	if (num_controllers > 0) {
 		for (i = 0; ; i++) {
-			unsigned int domain, bus, dev, func;
-
 			val = spdk_conf_section_get_nmval(sp, "BDF", i, 0);
 			if (val == NULL) {
 				break;
 			}
 
-			rc = sscanf(val, "%x:%x:%x.%x", &domain, &bus, &dev, &func);
-			if (rc != 4) {
+			if (spdk_pci_addr_parse(&probe_ctx.whitelist[probe_ctx.num_whitelist_controllers], val) < 0) {
 				SPDK_ERRLOG("Invalid format for BDF: %s\n", val);
 				return -1;
 			}
-
-			probe_ctx.whitelist[probe_ctx.num_whitelist_controllers].domain = domain;
-			probe_ctx.whitelist[probe_ctx.num_whitelist_controllers].bus = bus;
-			probe_ctx.whitelist[probe_ctx.num_whitelist_controllers].dev = dev;
-			probe_ctx.whitelist[probe_ctx.num_whitelist_controllers].func = func;
 
 			probe_ctx.num_whitelist_controllers++;
 		}

--- a/lib/bdev/nvme/blockdev_nvme.c
+++ b/lib/bdev/nvme/blockdev_nvme.c
@@ -414,10 +414,12 @@ blockdev_nvme_exist(struct nvme_probe_ctx *ctx)
 {
 	int i;
 	struct nvme_device *nvme_dev;
+	struct spdk_pci_addr dev_addr;
 
 	for (i = 0; i < ctx->num_whitelist_controllers; i++) {
 		TAILQ_FOREACH(nvme_dev, &g_nvme_devices, tailq) {
-			if (spdk_pci_device_compare_addr(nvme_dev->pci_dev, &ctx->whitelist[i])) {
+			dev_addr = spdk_pci_device_get_addr(nvme_dev->pci_dev);
+			if (spdk_pci_addr_compare(&dev_addr, &ctx->whitelist[i]) == 0) {
 				return true;
 			}
 		}

--- a/lib/bdev/nvme/blockdev_nvme.h
+++ b/lib/bdev/nvme/blockdev_nvme.h
@@ -35,14 +35,22 @@
 #define SPDK_BLOCKDEV_NVME_H
 
 #include <stdint.h>
+
+#include "spdk/bdev.h"
 #include "spdk/env.h"
 
 #define NVME_MAX_CONTROLLERS 16
+#define NVME_MAX_BLOCKDEVS_PER_CONTROLLER 256
+#define NVME_MAX_BLOCKDEVS (NVME_MAX_BLOCKDEVS_PER_CONTROLLER * NVME_MAX_CONTROLLERS)
 
 struct nvme_probe_ctx {
 	int controllers_remaining;
 	int num_whitelist_controllers;
 	struct spdk_pci_addr whitelist[NVME_MAX_CONTROLLERS];
+
+	/* Filled by spdk_bdev_nvme_create() with the bdevs that were added */
+	int num_created_bdevs;
+	struct spdk_bdev *created_bdevs[NVME_MAX_BLOCKDEVS];
 };
 
 int

--- a/lib/bdev/nvme/blockdev_nvme_rpc.c
+++ b/lib/bdev/nvme/blockdev_nvme_rpc.c
@@ -57,8 +57,7 @@ spdk_rpc_construct_nvme_bdev(struct spdk_jsonrpc_server_conn *conn,
 	struct rpc_construct_nvme req = {};
 	struct spdk_json_write_ctx *w;
 	struct nvme_probe_ctx ctx = {};
-	unsigned int domain, bus, dev, func;
-	int rc, i;
+	int i;
 
 	if (spdk_json_decode_object(params, rpc_construct_nvme_decoders,
 				    sizeof(rpc_construct_nvme_decoders) / sizeof(*rpc_construct_nvme_decoders),
@@ -70,15 +69,9 @@ spdk_rpc_construct_nvme_bdev(struct spdk_jsonrpc_server_conn *conn,
 	ctx.controllers_remaining = 1;
 	ctx.num_whitelist_controllers = 1;
 
-	rc = sscanf(req.pci_address, "%x:%x:%x.%x", &domain, &bus, &dev, &func);
-	if (rc != 4) {
+	if (spdk_pci_addr_parse(&ctx.whitelist[0], req.pci_address) < 0) {
 		goto invalid;
 	}
-
-	ctx.whitelist[0].domain = domain;
-	ctx.whitelist[0].bus = bus;
-	ctx.whitelist[0].dev = dev;
-	ctx.whitelist[0].func = func;
 
 	if (spdk_bdev_nvme_create(&ctx)) {
 		goto invalid;

--- a/lib/bdev/nvme/blockdev_nvme_rpc.c
+++ b/lib/bdev/nvme/blockdev_nvme_rpc.c
@@ -58,7 +58,7 @@ spdk_rpc_construct_nvme_bdev(struct spdk_jsonrpc_server_conn *conn,
 	struct spdk_json_write_ctx *w;
 	struct nvme_probe_ctx ctx = {};
 	unsigned int domain, bus, dev, func;
-	int rc;
+	int rc, i;
 
 	if (spdk_json_decode_object(params, rpc_construct_nvme_decoders,
 				    sizeof(rpc_construct_nvme_decoders) / sizeof(*rpc_construct_nvme_decoders),
@@ -91,7 +91,11 @@ spdk_rpc_construct_nvme_bdev(struct spdk_jsonrpc_server_conn *conn,
 	}
 
 	w = spdk_jsonrpc_begin_result(conn, id);
-	spdk_json_write_bool(w, true);
+	spdk_json_write_array_begin(w);
+	for (i = 0; i < ctx.num_created_bdevs; i++) {
+		spdk_json_write_string(w, ctx.created_bdevs[i]->name);
+	}
+	spdk_json_write_array_end(w);
 	spdk_jsonrpc_end_result(conn, w);
 	return;
 

--- a/lib/bdev/rbd/blockdev_rbd.h
+++ b/lib/bdev/rbd/blockdev_rbd.h
@@ -36,6 +36,9 @@
 
 #include <stdint.h>
 
-int
-spdk_bdev_rbd_create(const char *pool_name, const char *rbd_name, uint32_t block_size);
+#include "spdk/bdev.h"
+
+struct spdk_bdev *spdk_bdev_rbd_create(const char *pool_name, const char *rbd_name,
+				       uint32_t block_size);
+
 #endif // SPDK_BLOCKDEV_RBD_H

--- a/lib/bdev/rbd/blockdev_rbd_rpc.c
+++ b/lib/bdev/rbd/blockdev_rbd_rpc.c
@@ -38,7 +38,7 @@
 struct rpc_construct_rbd {
 	char *pool_name;
 	char *rbd_name;
-	int32_t size;
+	uint32_t block_size;
 };
 
 static void
@@ -51,7 +51,7 @@ free_rpc_construct_rbd(struct rpc_construct_rbd *req)
 static const struct spdk_json_object_decoder rpc_construct_rbd_decoders[] = {
 	{"pool_name", offsetof(struct rpc_construct_rbd, pool_name), spdk_json_decode_string},
 	{"rbd_name", offsetof(struct rpc_construct_rbd, rbd_name), spdk_json_decode_string},
-	{"size", offsetof(struct rpc_construct_rbd, size), spdk_json_decode_int32},
+	{"block_size", offsetof(struct rpc_construct_rbd, block_size), spdk_json_decode_uint32},
 };
 
 static void
@@ -70,7 +70,7 @@ spdk_rpc_construct_rbd_bdev(struct spdk_jsonrpc_server_conn *conn,
 		goto invalid;
 	}
 
-	bdev = spdk_bdev_rbd_create(req.pool_name, req.rbd_name, req.size);
+	bdev = spdk_bdev_rbd_create(req.pool_name, req.rbd_name, req.block_size);
 	if (bdev == NULL) {
 		goto invalid;
 	}

--- a/lib/bdev/rbd/blockdev_rbd_rpc.c
+++ b/lib/bdev/rbd/blockdev_rbd_rpc.c
@@ -61,6 +61,7 @@ spdk_rpc_construct_rbd_bdev(struct spdk_jsonrpc_server_conn *conn,
 {
 	struct rpc_construct_rbd req = {};
 	struct spdk_json_write_ctx *w;
+	struct spdk_bdev *bdev;
 
 	if (spdk_json_decode_object(params, rpc_construct_rbd_decoders,
 				    sizeof(rpc_construct_rbd_decoders) / sizeof(*rpc_construct_rbd_decoders),
@@ -69,7 +70,8 @@ spdk_rpc_construct_rbd_bdev(struct spdk_jsonrpc_server_conn *conn,
 		goto invalid;
 	}
 
-	if (spdk_bdev_rbd_create(req.pool_name, req.rbd_name, req.size)) {
+	bdev = spdk_bdev_rbd_create(req.pool_name, req.rbd_name, req.size);
+	if (bdev == NULL) {
 		goto invalid;
 	}
 
@@ -80,7 +82,9 @@ spdk_rpc_construct_rbd_bdev(struct spdk_jsonrpc_server_conn *conn,
 	}
 
 	w = spdk_jsonrpc_begin_result(conn, id);
-	spdk_json_write_bool(w, true);
+	spdk_json_write_array_begin(w);
+	spdk_json_write_string(w, bdev->name);
+	spdk_json_write_array_end(w);
 	spdk_jsonrpc_end_result(conn, w);
 	return;
 

--- a/lib/bdev/rpc/Makefile
+++ b/lib/bdev/rpc/Makefile
@@ -31,19 +31,11 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-SPDK_ROOT_DIR := $(abspath $(CURDIR)/../..)
+SPDK_ROOT_DIR := $(abspath $(CURDIR)/../../..)
 include $(SPDK_ROOT_DIR)/mk/spdk.common.mk
 
-CFLAGS += $(ENV_CFLAGS) -I.
-C_SRCS = bdev.c
-LIBNAME = bdev
-
-DIRS-y += malloc nvme rpc
-
-ifeq ($(OS),Linux)
-DIRS-y += aio
-endif
-
-DIRS-$(CONFIG_RBD) += rbd
+CFLAGS += -I$(SPDK_ROOT_DIR)/lib/bdev/
+C_SRCS = bdev_rpc.c
+LIBNAME = bdev_rpc
 
 include $(SPDK_ROOT_DIR)/mk/spdk.lib.mk

--- a/lib/bdev/rpc/bdev_rpc.c
+++ b/lib/bdev/rpc/bdev_rpc.c
@@ -1,0 +1,83 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright (c) Intel Corporation.
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "spdk/bdev.h"
+#include "spdk/log.h"
+#include "spdk/rpc.h"
+
+static void
+spdk_rpc_get_bdevs(struct spdk_jsonrpc_server_conn *conn,
+		   const struct spdk_json_val *params,
+		   const struct spdk_json_val *id)
+{
+	struct spdk_json_write_ctx *w;
+	struct spdk_bdev *bdev;
+
+	if (params != NULL) {
+		spdk_jsonrpc_send_error_response(conn, id, SPDK_JSONRPC_ERROR_INVALID_PARAMS,
+						 "get_bdevs requires no parameters");
+		return;
+	}
+
+	if (id == NULL) {
+		return;
+	}
+
+	w = spdk_jsonrpc_begin_result(conn, id);
+	spdk_json_write_array_begin(w);
+
+	for (bdev = spdk_bdev_first(); bdev != NULL; bdev = spdk_bdev_next(bdev)) {
+		spdk_json_write_object_begin(w);
+
+		spdk_json_write_name(w, "name");
+		spdk_json_write_string(w, bdev->name);
+
+		spdk_json_write_name(w, "product_name");
+		spdk_json_write_string(w, bdev->product_name);
+
+		spdk_json_write_name(w, "block_size");
+		spdk_json_write_uint32(w, bdev->blocklen);
+
+		spdk_json_write_name(w, "num_blocks");
+		spdk_json_write_uint64(w, bdev->blockcnt);
+
+		spdk_json_write_name(w, "claimed");
+		spdk_json_write_bool(w, bdev->claimed);
+
+		spdk_json_write_object_end(w);
+	}
+	spdk_json_write_array_end(w);
+
+	spdk_jsonrpc_end_result(conn, w);
+}
+SPDK_RPC_REGISTER("get_bdevs", spdk_rpc_get_bdevs)

--- a/lib/copy/ioat/copy_engine_ioat.c
+++ b/lib/copy/ioat/copy_engine_ioat.c
@@ -241,11 +241,12 @@ static bool
 probe_cb(void *cb_ctx, struct spdk_pci_device *pci_dev)
 {
 	struct ioat_probe_ctx *ctx = cb_ctx;
+	struct spdk_pci_addr pci_addr = spdk_pci_device_get_addr(pci_dev);
 
 	SPDK_NOTICELOG(" Found matching device at %d:%d:%d vendor:0x%04x device:0x%04x\n   name:%s\n",
-		       spdk_pci_device_get_bus(pci_dev),
-		       spdk_pci_device_get_dev(pci_dev),
-		       spdk_pci_device_get_func(pci_dev),
+		       pci_addr.bus,
+		       pci_addr.dev,
+		       pci_addr.func,
 		       spdk_pci_device_get_vendor_id(pci_dev),
 		       spdk_pci_device_get_device_id(pci_dev),
 		       spdk_pci_device_get_device_name(pci_dev));
@@ -256,7 +257,7 @@ probe_cb(void *cb_ctx, struct spdk_pci_device *pci_dev)
 	}
 
 	/* Claim the device in case conflict with other process */
-	if (spdk_pci_device_claim(pci_dev) != 0) {
+	if (spdk_pci_device_claim(&pci_addr) != 0) {
 		return false;
 	}
 

--- a/lib/copy/ioat/copy_engine_ioat.c
+++ b/lib/copy/ioat/copy_engine_ioat.c
@@ -236,13 +236,12 @@ probe_cb(void *cb_ctx, struct spdk_pci_device *pci_dev)
 	struct ioat_probe_ctx *ctx = cb_ctx;
 	struct spdk_pci_addr pci_addr = spdk_pci_device_get_addr(pci_dev);
 
-	SPDK_NOTICELOG(" Found matching device at %d:%d:%d vendor:0x%04x device:0x%04x\n   name:%s\n",
+	SPDK_NOTICELOG(" Found matching device at %d:%d:%d vendor:0x%04x device:0x%04x\n",
 		       pci_addr.bus,
 		       pci_addr.dev,
 		       pci_addr.func,
 		       spdk_pci_device_get_vendor_id(pci_dev),
-		       spdk_pci_device_get_device_id(pci_dev),
-		       spdk_pci_device_get_device_name(pci_dev));
+		       spdk_pci_device_get_device_id(pci_dev));
 
 	if (ctx->num_whitelist_devices > 0 &&
 	    !ioat_find_dev_by_whitelist_bdf(&pci_addr, ctx->whitelist, ctx->num_whitelist_devices)) {

--- a/lib/copy/ioat/copy_engine_ioat.c
+++ b/lib/copy/ioat/copy_engine_ioat.c
@@ -279,7 +279,6 @@ copy_engine_ioat_init(void)
 	const char *val, *pci_bdf;
 	int i;
 	struct ioat_probe_ctx probe_ctx = {};
-	unsigned bus, dev, func;
 
 	if (sp != NULL) {
 		val = spdk_conf_section_get_val(sp, "Disable");
@@ -294,11 +293,11 @@ copy_engine_ioat_init(void)
 			pci_bdf = spdk_conf_section_get_nmval(sp, "Whitelist", i, 0);
 			if (!pci_bdf)
 				break;
-			sscanf(pci_bdf, "%02x:%02x.%1u", &bus, &dev, &func);
-			probe_ctx.whitelist[probe_ctx.num_whitelist_devices].domain = 0;
-			probe_ctx.whitelist[probe_ctx.num_whitelist_devices].bus = bus;
-			probe_ctx.whitelist[probe_ctx.num_whitelist_devices].dev = dev;
-			probe_ctx.whitelist[probe_ctx.num_whitelist_devices].func = func;
+
+			if (spdk_pci_addr_parse(&probe_ctx.whitelist[probe_ctx.num_whitelist_devices], pci_bdf) < 0) {
+				SPDK_ERRLOG("Invalid Ioat Whitelist address %s\n", pci_bdf);
+				return -1;
+			}
 			probe_ctx.num_whitelist_devices++;
 		}
 	}

--- a/lib/env/env.c
+++ b/lib/env/env.c
@@ -43,14 +43,21 @@
 #include <rte_version.h>
 
 void *
-spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
+spdk_malloc(size_t size, size_t align, uint64_t *phys_addr)
 {
 	void *buf = rte_malloc(NULL, size, align);
+	if (buf && phys_addr) {
+		*phys_addr = rte_malloc_virt2phy(buf);
+	}
+	return buf;
+}
+
+void *
+spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
+{
+	void *buf = spdk_malloc(size, align, phys_addr);
 	if (buf) {
 		memset(buf, 0, size);
-		if (phys_addr) {
-			*phys_addr = rte_malloc_virt2phy(buf);
-		}
 	}
 	return buf;
 }

--- a/lib/env/pci.c
+++ b/lib/env/pci.c
@@ -394,13 +394,41 @@ spdk_pci_device_get_serial_number(struct spdk_pci_device *dev, char *sn, size_t 
 	return -1;
 }
 
-bool
-spdk_pci_device_compare_addr(struct spdk_pci_device *dev, struct spdk_pci_addr *addr)
+struct spdk_pci_addr
+spdk_pci_device_get_addr(struct spdk_pci_device *pci_dev)
 {
-	return ((spdk_pci_device_get_domain(dev) == addr->domain) &&
-		(spdk_pci_device_get_bus(dev) == addr->bus) &&
-		(spdk_pci_device_get_dev(dev) == addr->dev) &&
-		(spdk_pci_device_get_func(dev) == addr->func));
+	struct spdk_pci_addr pci_addr;
+
+	pci_addr.domain = spdk_pci_device_get_domain(pci_dev);
+	pci_addr.bus = spdk_pci_device_get_bus(pci_dev);
+	pci_addr.dev = spdk_pci_device_get_dev(pci_dev);
+	pci_addr.func = spdk_pci_device_get_func(pci_dev);
+
+	return pci_addr;
+}
+
+int
+spdk_pci_addr_compare(const struct spdk_pci_addr *a1, const struct spdk_pci_addr *a2)
+{
+	if (a1->domain > a2->domain) {
+		return 1;
+	} else if (a1->domain < a2->domain) {
+		return -1;
+	} else if (a1->bus > a2->bus) {
+		return 1;
+	} else if (a1->bus < a2->bus) {
+		return -1;
+	} else if (a1->dev > a2->dev) {
+		return 1;
+	} else if (a1->dev < a2->dev) {
+		return -1;
+	} else if (a1->func > a2->func) {
+		return 1;
+	} else if (a1->func < a2->func) {
+		return -1;
+	}
+
+	return 0;
 }
 
 #ifdef __linux__

--- a/lib/env/pci.c
+++ b/lib/env/pci.c
@@ -324,13 +324,6 @@ spdk_pci_device_get_class(struct spdk_pci_device *dev)
 	return class_code;
 }
 
-const char *
-spdk_pci_device_get_device_name(struct spdk_pci_device *dev)
-{
-	/* TODO */
-	return NULL;
-}
-
 int
 spdk_pci_device_cfg_read8(struct spdk_pci_device *dev, uint8_t *value, uint32_t offset)
 {

--- a/lib/env/pci.c
+++ b/lib/env/pci.c
@@ -505,3 +505,37 @@ spdk_pci_device_claim(const struct spdk_pci_addr *pci_addr)
 	return 0;
 }
 #endif /* __FreeBSD__ */
+
+int
+spdk_pci_addr_parse(struct spdk_pci_addr *addr, const char *bdf)
+{
+	unsigned domain, bus, dev, func;
+
+	if (addr == NULL || bdf == NULL) {
+		return -EINVAL;
+	}
+
+	if (sscanf(bdf, "%x:%x:%x.%x", &domain, &bus, &dev, &func) == 4) {
+		/* Matched a full address - all variables are initialized */
+	} else if (sscanf(bdf, "%x:%x:%x", &domain, &bus, &dev) == 3) {
+		func = 0;
+	} else if (sscanf(bdf, "%x:%x.%x", &bus, &dev, &func) == 3) {
+		domain = 0;
+	} else if (sscanf(bdf, "%x:%x", &bus, &dev) == 2) {
+		domain = 0;
+		func = 0;
+	} else {
+		return -EINVAL;
+	}
+
+	if (domain > 0xFFFF || bus > 0xFF || dev > 0x1F || func > 7) {
+		return -EINVAL;
+	}
+
+	addr->domain = domain;
+	addr->bus = bus;
+	addr->dev = dev;
+	addr->func = func;
+
+	return 0;
+}

--- a/lib/env/pci.c
+++ b/lib/env/pci.c
@@ -299,6 +299,19 @@ spdk_pci_device_get_subdevice_id(struct spdk_pci_device *dev)
 	return dev->id.subsystem_device_id;
 }
 
+struct spdk_pci_id
+spdk_pci_device_get_id(struct spdk_pci_device *pci_dev)
+{
+	struct spdk_pci_id pci_id;
+
+	pci_id.vendor_id = spdk_pci_device_get_vendor_id(pci_dev);
+	pci_id.device_id = spdk_pci_device_get_device_id(pci_dev);
+	pci_id.subvendor_id = spdk_pci_device_get_subvendor_id(pci_dev);
+	pci_id.subdevice_id = spdk_pci_device_get_subdevice_id(pci_dev);
+
+	return pci_id;
+}
+
 uint32_t
 spdk_pci_device_get_class(struct spdk_pci_device *dev)
 {

--- a/lib/env/pci.c
+++ b/lib/env/pci.c
@@ -446,7 +446,7 @@ spdk_pci_addr_compare(const struct spdk_pci_addr *a1, const struct spdk_pci_addr
 
 #ifdef __linux__
 int
-spdk_pci_device_claim(struct spdk_pci_device *dev)
+spdk_pci_device_claim(const struct spdk_pci_addr *pci_addr)
 {
 	int dev_fd;
 	char shm_name[64];
@@ -459,9 +459,7 @@ spdk_pci_device_claim(struct spdk_pci_device *dev)
 		.l_len = 0,
 	};
 
-	sprintf(shm_name, PCI_PRI_FMT, spdk_pci_device_get_domain(dev),
-		spdk_pci_device_get_bus(dev), spdk_pci_device_get_dev(dev),
-		spdk_pci_device_get_func(dev));
+	sprintf(shm_name, PCI_PRI_FMT, pci_addr->domain, pci_addr->bus, pci_addr->dev, pci_addr->func);
 
 	dev_fd = shm_open(shm_name, O_RDWR | O_CREAT, 0600);
 	if (dev_fd == -1) {
@@ -501,7 +499,7 @@ spdk_pci_device_claim(struct spdk_pci_device *dev)
 
 #ifdef __FreeBSD__
 int
-spdk_pci_device_claim(struct spdk_pci_device *dev)
+spdk_pci_device_claim(const struct spdk_pci_addr *pci_addr)
 {
 	/* TODO */
 	return 0;

--- a/lib/iscsi/conn.c
+++ b/lib/iscsi/conn.c
@@ -914,6 +914,7 @@ void process_task_completion(spdk_event_t event)
 		    (task->scsi.status != SPDK_SCSI_STATUS_GOOD)) {
 			memcpy(primary->scsi.sense_data, task->scsi.sense_data,
 			       task->scsi.sense_data_len);
+			primary->scsi.sense_data_len = task->scsi.sense_data_len;
 			primary->scsi.status = task->scsi.status;
 		}
 

--- a/lib/iscsi/iscsi.h
+++ b/lib/iscsi/iscsi.h
@@ -183,6 +183,11 @@ struct spdk_iscsi_pdu {
 	 * we need to not zero this out when doing memory clear.
 	 */
 	uint8_t ahs_data[ISCSI_AHS_LEN];
+
+	struct {
+		uint16_t length; /* iSCSI SenseLength (big-endian) */
+		uint8_t data[32];
+	} sense;
 };
 
 enum iscsi_connection_state {

--- a/lib/iscsi/iscsi_subsystem.c
+++ b/lib/iscsi/iscsi_subsystem.c
@@ -515,7 +515,7 @@ struct spdk_iscsi_pdu *spdk_get_pdu(void)
 		rte_panic("no memory\n");
 	}
 
-	/* we do not want to zero out the last 60 bytes reserved for AHS */
+	/* we do not want to zero out the last part of the structure reserved for AHS and sense data */
 	memset(pdu, 0, offsetof(struct spdk_iscsi_pdu, ahs_data));
 	pdu->ref = 1;
 

--- a/lib/json/json_write.c
+++ b/lib/json/json_write.c
@@ -36,6 +36,9 @@
 struct spdk_json_write_ctx {
 	spdk_json_write_cb write_cb;
 	void *cb_ctx;
+	uint32_t flags;
+	uint32_t indent;
+	bool new_indent;
 	bool first_value;
 	bool failed;
 };
@@ -52,6 +55,9 @@ spdk_json_write_begin(spdk_json_write_cb write_cb, void *cb_ctx, uint32_t flags)
 
 	w->write_cb = write_cb;
 	w->cb_ctx = cb_ctx;
+	w->flags = flags;
+	w->indent = 0;
+	w->new_indent = false;
 	w->first_value = true;
 	w->failed = false;
 
@@ -94,13 +100,42 @@ emit(struct spdk_json_write_ctx *w, const void *data, size_t size)
 }
 
 static int
+emit_fmt(struct spdk_json_write_ctx *w, const void *data, size_t size)
+{
+	if (w->flags & SPDK_JSON_WRITE_FLAG_FORMATTED) {
+		return emit(w, data, size);
+	}
+	return 0;
+}
+
+static int
+emit_indent(struct spdk_json_write_ctx *w)
+{
+	uint32_t i;
+
+	if (w->flags & SPDK_JSON_WRITE_FLAG_FORMATTED) {
+		for (i = 0; i < w->indent; i++) {
+			if (emit(w, "  ", 2)) return fail(w);
+		}
+	}
+	return 0;
+}
+
+static int
 begin_value(struct spdk_json_write_ctx *w)
 {
 	// TODO: check for value state
+	if (w->new_indent) {
+		if (emit_fmt(w, "\n", 1)) return fail(w);
+		if (emit_indent(w)) return fail(w);
+	}
 	if (!w->first_value) {
 		if (emit(w, ",", 1)) return fail(w);
+		if (emit_fmt(w, "\n", 1)) return fail(w);
+		if (emit_indent(w)) return fail(w);
 	}
 	w->first_value = false;
+	w->new_indent = false;
 	return 0;
 }
 
@@ -263,13 +298,23 @@ spdk_json_write_array_begin(struct spdk_json_write_ctx *w)
 {
 	if (begin_value(w)) return fail(w);
 	w->first_value = true;
-	return emit(w, "[", 1);
+	w->new_indent = true;
+	w->indent++;
+	if (emit(w, "[", 1)) return fail(w);
+	return 0;
 }
 
 int
 spdk_json_write_array_end(struct spdk_json_write_ctx *w)
 {
 	w->first_value = false;
+	if (w->indent == 0) return fail(w);
+	w->indent--;
+	if (!w->new_indent) {
+		if (emit_fmt(w, "\n", 1)) return fail(w);
+		if (emit_indent(w)) return fail(w);
+	}
+	w->new_indent = false;
 	return emit(w, "]", 1);
 }
 
@@ -278,13 +323,22 @@ spdk_json_write_object_begin(struct spdk_json_write_ctx *w)
 {
 	if (begin_value(w)) return fail(w);
 	w->first_value = true;
-	return emit(w, "{", 1);
+	w->new_indent = true;
+	w->indent++;
+	if (emit(w, "{", 1)) return fail(w);
+	return 0;
 }
 
 int
 spdk_json_write_object_end(struct spdk_json_write_ctx *w)
 {
 	w->first_value = false;
+	w->indent--;
+	if (!w->new_indent) {
+		if (emit_fmt(w, "\n", 1)) return fail(w);
+		if (emit_indent(w)) return fail(w);
+	}
+	w->new_indent = false;
 	return emit(w, "}", 1);
 }
 
@@ -295,7 +349,8 @@ spdk_json_write_name_raw(struct spdk_json_write_ctx *w, const char *name, size_t
 	if (begin_value(w)) return fail(w);
 	if (write_string_or_name(w, name, len)) return fail(w);
 	w->first_value = true;
-	return emit(w, ":", 1);
+	if (emit(w, ":", 1)) return fail(w);
+	return emit_fmt(w, " ", 1);
 }
 
 int

--- a/lib/json/json_write.c
+++ b/lib/json/json_write.c
@@ -188,6 +188,30 @@ spdk_json_write_uint32(struct spdk_json_write_ctx *w, uint32_t val)
 	return emit(w, buf, count);
 }
 
+int
+spdk_json_write_int64(struct spdk_json_write_ctx *w, int64_t val)
+{
+	char buf[32];
+	int count;
+
+	if (begin_value(w)) return fail(w);
+	count = snprintf(buf, sizeof(buf), "%" PRId64, val);
+	if (count <= 0 || (size_t)count >= sizeof(buf)) return fail(w);
+	return emit(w, buf, count);
+}
+
+int
+spdk_json_write_uint64(struct spdk_json_write_ctx *w, uint64_t val)
+{
+	char buf[32];
+	int count;
+
+	if (begin_value(w)) return fail(w);
+	count = snprintf(buf, sizeof(buf), "%" PRIu64, val);
+	if (count <= 0 || (size_t)count >= sizeof(buf)) return fail(w);
+	return emit(w, buf, count);
+}
+
 static void
 write_hex_4(void *dest, uint16_t val)
 {

--- a/lib/nvme/nvme.c
+++ b/lib/nvme/nvme.c
@@ -107,6 +107,7 @@ nvme_allocate_request(const struct nvme_payload *payload, uint32_t payload_size,
 	req->cb_arg = cb_arg;
 	req->payload = *payload;
 	req->payload_size = payload_size;
+	req->pid = getpid();
 
 	return req;
 }
@@ -142,6 +143,7 @@ nvme_user_copy_cmd_complete(void *arg, const struct spdk_nvme_cpl *cpl)
 		xfer = spdk_nvme_opc_get_data_transfer(req->cmd.opc);
 		if (xfer == SPDK_NVME_DATA_CONTROLLER_TO_HOST ||
 		    xfer == SPDK_NVME_DATA_BIDIRECTIONAL) {
+			assert(req->pid == getpid());
 			memcpy(req->user_buffer, req->payload.u.contig, req->payload_size);
 		}
 

--- a/lib/nvme/nvme.c
+++ b/lib/nvme/nvme.c
@@ -232,8 +232,10 @@ nvme_enum_cb(void *ctx, struct spdk_pci_device *pci_dev)
 	struct spdk_nvme_ctrlr *ctrlr;
 	struct spdk_nvme_ctrlr_opts opts;
 	struct spdk_pci_addr dev_addr;
+	struct spdk_nvme_probe_info probe_info;
 
-	dev_addr = spdk_pci_device_get_addr(pci_dev);
+	probe_info.pci_addr = spdk_pci_device_get_addr(pci_dev);
+	probe_info.pci_id = spdk_pci_device_get_id(pci_dev);
 
 	/* Verify that this controller is not already attached */
 	TAILQ_FOREACH(ctrlr, &g_spdk_nvme_driver->attached_ctrlrs, tailq) {
@@ -241,14 +243,14 @@ nvme_enum_cb(void *ctx, struct spdk_pci_device *pci_dev)
 		 * different per each process, we compare by BDF to determine whether it is the
 		 * same controller.
 		 */
-		if (spdk_pci_addr_compare(&dev_addr, &ctrlr->pci_addr) == 0) {
+		if (spdk_pci_addr_compare(&dev_addr, &ctrlr->probe_info.pci_addr) == 0) {
 			return 0;
 		}
 	}
 
 	spdk_nvme_ctrlr_opts_set_defaults(&opts);
 
-	if (enum_ctx->probe_cb(enum_ctx->cb_ctx, pci_dev, &opts)) {
+	if (enum_ctx->probe_cb(enum_ctx->cb_ctx, &probe_info, &opts)) {
 		ctrlr = nvme_attach(pci_dev);
 		if (ctrlr == NULL) {
 			SPDK_ERRLOG("nvme_attach() failed\n");
@@ -256,6 +258,7 @@ nvme_enum_cb(void *ctx, struct spdk_pci_device *pci_dev)
 		}
 
 		ctrlr->opts = opts;
+		ctrlr->probe_info = probe_info;
 
 		TAILQ_INSERT_TAIL(&g_spdk_nvme_driver->init_ctrlrs, ctrlr, tailq);
 	}
@@ -329,7 +332,7 @@ spdk_nvme_probe(void *cb_ctx, spdk_nvme_probe_cb probe_cb, spdk_nvme_attach_cb a
 				 *  that may take the driver lock, like nvme_detach().
 				 */
 				pthread_mutex_unlock(&g_spdk_nvme_driver->lock);
-				attach_cb(cb_ctx, ctrlr->devhandle, ctrlr, &ctrlr->opts);
+				attach_cb(cb_ctx, &ctrlr->probe_info, ctrlr, &ctrlr->opts);
 				pthread_mutex_lock(&g_spdk_nvme_driver->lock);
 
 				break;

--- a/lib/nvme/nvme.c
+++ b/lib/nvme/nvme.c
@@ -229,6 +229,9 @@ nvme_enum_cb(void *ctx, struct spdk_pci_device *pci_dev)
 	struct nvme_enum_ctx *enum_ctx = ctx;
 	struct spdk_nvme_ctrlr *ctrlr;
 	struct spdk_nvme_ctrlr_opts opts;
+	struct spdk_pci_addr dev_addr;
+
+	dev_addr = spdk_pci_device_get_addr(pci_dev);
 
 	/* Verify that this controller is not already attached */
 	TAILQ_FOREACH(ctrlr, &g_spdk_nvme_driver->attached_ctrlrs, tailq) {
@@ -236,7 +239,7 @@ nvme_enum_cb(void *ctx, struct spdk_pci_device *pci_dev)
 		 * different per each process, we compare by BDF to determine whether it is the
 		 * same controller.
 		 */
-		if (spdk_pci_device_compare_addr(pci_dev, &ctrlr->pci_addr)) {
+		if (spdk_pci_addr_compare(&dev_addr, &ctrlr->pci_addr) == 0) {
 			return 0;
 		}
 	}

--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -163,7 +163,7 @@ static void
 nvme_ctrlr_construct_intel_support_log_page_list(struct spdk_nvme_ctrlr *ctrlr,
 		struct spdk_nvme_intel_log_page_directory *log_page_directory)
 {
-	struct pci_id pci_id;
+	struct spdk_pci_id pci_id;
 
 	if (log_page_directory == NULL) {
 		return;
@@ -995,7 +995,7 @@ nvme_mutex_init_recursive_shared(pthread_mutex_t *mtx)
 int
 nvme_ctrlr_construct(struct spdk_nvme_ctrlr *ctrlr)
 {
-	struct pci_id pci_id;
+	struct spdk_pci_id pci_id;
 
 	nvme_ctrlr_set_state(ctrlr, NVME_CTRLR_STATE_INIT, NVME_TIMEOUT_INFINITE);
 	ctrlr->flags = 0;

--- a/lib/nvme/nvme_internal.h
+++ b/lib/nvme/nvme_internal.h
@@ -347,6 +347,9 @@ struct spdk_nvme_ctrlr {
 	enum nvme_ctrlr_state		state;
 	uint64_t			state_timeout_tsc;
 
+	uint64_t			next_keep_alive_tick;
+	uint64_t			keep_alive_interval_ticks;
+
 	TAILQ_ENTRY(spdk_nvme_ctrlr)	tailq;
 
 	/** All the log pages supported */

--- a/lib/nvme/nvme_internal.h
+++ b/lib/nvme/nvme_internal.h
@@ -207,20 +207,13 @@ struct nvme_request {
 	void				*user_buffer;
 };
 
-struct pci_id {
-	uint16_t	vendor_id;
-	uint16_t	dev_id;
-	uint16_t	sub_vendor_id;
-	uint16_t	sub_dev_id;
-};
-
 struct spdk_nvme_transport {
 	struct spdk_nvme_ctrlr *(*ctrlr_construct)(void *devhandle);
 	void (*ctrlr_destruct)(struct spdk_nvme_ctrlr *ctrlr);
 
 	int (*ctrlr_enable)(struct spdk_nvme_ctrlr *ctrlr);
 
-	int (*ctrlr_get_pci_id)(struct spdk_nvme_ctrlr *ctrlr, struct pci_id *pci_id);
+	int (*ctrlr_get_pci_id)(struct spdk_nvme_ctrlr *ctrlr, struct spdk_pci_id *pci_id);
 
 	int (*ctrlr_set_reg_4)(struct spdk_nvme_ctrlr *ctrlr, uint32_t offset, uint32_t value);
 	int (*ctrlr_set_reg_8)(struct spdk_nvme_ctrlr *ctrlr, uint32_t offset, uint64_t value);
@@ -514,7 +507,7 @@ struct nvme_request *nvme_allocate_request_user_copy(void *buffer, uint32_t payl
 		spdk_nvme_cmd_cb cb_fn, void *cb_arg, bool host_to_controller);
 void	nvme_free_request(struct nvme_request *req);
 void	nvme_request_remove_child(struct nvme_request *parent, struct nvme_request *child);
-uint64_t nvme_get_quirks(const struct pci_id *id);
+uint64_t nvme_get_quirks(const struct spdk_pci_id *id);
 
 void	spdk_nvme_ctrlr_opts_set_defaults(struct spdk_nvme_ctrlr_opts *opts);
 

--- a/lib/nvme/nvme_internal.h
+++ b/lib/nvme/nvme_internal.h
@@ -417,8 +417,7 @@ struct spdk_nvme_ctrlr {
 
 	struct spdk_nvme_ctrlr_opts	opts;
 
-	/** PCI address including domain, bus, device and function */
-	struct spdk_pci_addr		pci_addr;
+	struct spdk_nvme_probe_info	probe_info;
 
 	uint64_t			quirks;
 

--- a/lib/nvme/nvme_internal.h
+++ b/lib/nvme/nvme_internal.h
@@ -492,7 +492,8 @@ int	nvme_ctrlr_submit_admin_request(struct spdk_nvme_ctrlr *ctrlr,
 int	nvme_ctrlr_get_cap(struct spdk_nvme_ctrlr *ctrlr, union spdk_nvme_cap_register *cap);
 int	nvme_qpair_construct(struct spdk_nvme_qpair *qpair, uint16_t id,
 			     uint16_t num_entries,
-			     struct spdk_nvme_ctrlr *ctrlr);
+			     struct spdk_nvme_ctrlr *ctrlr,
+			     enum spdk_nvme_qprio qprio);
 void	nvme_qpair_destroy(struct spdk_nvme_qpair *qpair);
 void	nvme_qpair_enable(struct spdk_nvme_qpair *qpair);
 void	nvme_qpair_disable(struct spdk_nvme_qpair *qpair);

--- a/lib/nvme/nvme_ns.c
+++ b/lib/nvme/nvme_ns.c
@@ -183,7 +183,7 @@ spdk_nvme_ns_get_data(struct spdk_nvme_ns *ns)
 int nvme_ns_construct(struct spdk_nvme_ns *ns, uint16_t id,
 		      struct spdk_nvme_ctrlr *ctrlr)
 {
-	struct pci_id pci_id;
+	struct spdk_pci_id pci_id;
 
 	assert(id > 0);
 
@@ -193,7 +193,7 @@ int nvme_ns_construct(struct spdk_nvme_ns *ns, uint16_t id,
 
 	if (ctrlr->transport->ctrlr_get_pci_id(ctrlr, &pci_id) == 0) {
 		if (pci_id.vendor_id == SPDK_PCI_VID_INTEL &&
-		    pci_id.dev_id == INTEL_DC_P3X00_DEVID &&
+		    pci_id.device_id == INTEL_DC_P3X00_DEVID &&
 		    ctrlr->cdata.vs[3] != 0) {
 			ns->stripe_size = (1 << ctrlr->cdata.vs[3]) * ctrlr->min_page_size;
 		}

--- a/lib/nvme/nvme_pcie.c
+++ b/lib/nvme/nvme_pcie.c
@@ -180,15 +180,10 @@ nvme_pcie_qpair(struct spdk_nvme_qpair *qpair)
 static int
 nvme_pcie_ctrlr_get_pci_id(struct spdk_nvme_ctrlr *ctrlr, struct spdk_pci_id *pci_id)
 {
-	struct spdk_pci_device *pci_dev;
-
 	assert(ctrlr != NULL);
 	assert(pci_id != NULL);
 
-	pci_dev = ctrlr->devhandle;
-	assert(pci_dev != NULL);
-
-	*pci_id = spdk_pci_device_get_id(pci_dev);
+	*pci_id = ctrlr->probe_info.pci_id;
 
 	return 0;
 }
@@ -470,12 +465,6 @@ static struct spdk_nvme_ctrlr *nvme_pcie_ctrlr_construct(void *devhandle)
 	/* Doorbell stride is 2 ^ (dstrd + 2),
 	 * but we want multiples of 4, so drop the + 2 */
 	pctrlr->doorbell_stride_u32 = 1 << cap.bits.dstrd;
-
-	/* Save the PCI address */
-	pctrlr->ctrlr.pci_addr.domain = spdk_pci_device_get_domain(pci_dev);
-	pctrlr->ctrlr.pci_addr.bus = spdk_pci_device_get_bus(pci_dev);
-	pctrlr->ctrlr.pci_addr.dev = spdk_pci_device_get_dev(pci_dev);
-	pctrlr->ctrlr.pci_addr.func = spdk_pci_device_get_func(pci_dev);
 
 	rc = nvme_ctrlr_construct(&pctrlr->ctrlr);
 	if (rc != 0) {

--- a/lib/nvme/nvme_pcie.c
+++ b/lib/nvme/nvme_pcie.c
@@ -430,7 +430,8 @@ nvme_pcie_ctrlr_construct_admin_qpair(struct spdk_nvme_ctrlr *ctrlr)
 	return nvme_qpair_construct(ctrlr->adminq,
 				    0, /* qpair ID */
 				    NVME_ADMIN_ENTRIES,
-				    ctrlr);
+				    ctrlr,
+				    SPDK_NVME_QPRIO_URGENT);
 }
 
 static struct spdk_nvme_ctrlr *nvme_pcie_ctrlr_construct(void *devhandle)
@@ -1059,9 +1060,6 @@ nvme_pcie_ctrlr_create_io_qpair(struct spdk_nvme_ctrlr *ctrlr, uint16_t qid,
 
 	qpair = &pqpair->qpair;
 
-	qpair->id = qid;
-	qpair->qprio = qprio;
-
 	/*
 	 * NVMe spec sets a hard limit of 64K max entries, but
 	 *  devices may specify a smaller limit, so we need to check
@@ -1069,7 +1067,7 @@ nvme_pcie_ctrlr_create_io_qpair(struct spdk_nvme_ctrlr *ctrlr, uint16_t qid,
 	 */
 	num_entries = nvme_min(NVME_IO_ENTRIES, ctrlr->cap.bits.mqes + 1);
 
-	rc = nvme_qpair_construct(qpair, qid, num_entries, ctrlr);
+	rc = nvme_qpair_construct(qpair, qid, num_entries, ctrlr, qprio);
 	if (rc != 0) {
 		free(pqpair);
 		return NULL;

--- a/lib/nvme/nvme_pcie.c
+++ b/lib/nvme/nvme_pcie.c
@@ -178,7 +178,7 @@ nvme_pcie_qpair(struct spdk_nvme_qpair *qpair)
 }
 
 static int
-nvme_pcie_ctrlr_get_pci_id(struct spdk_nvme_ctrlr *ctrlr, struct pci_id *pci_id)
+nvme_pcie_ctrlr_get_pci_id(struct spdk_nvme_ctrlr *ctrlr, struct spdk_pci_id *pci_id)
 {
 	struct spdk_pci_device *pci_dev;
 
@@ -188,10 +188,7 @@ nvme_pcie_ctrlr_get_pci_id(struct spdk_nvme_ctrlr *ctrlr, struct pci_id *pci_id)
 	pci_dev = ctrlr->devhandle;
 	assert(pci_dev != NULL);
 
-	pci_id->vendor_id = spdk_pci_device_get_vendor_id(pci_dev);
-	pci_id->dev_id = spdk_pci_device_get_device_id(pci_dev);
-	pci_id->sub_vendor_id = spdk_pci_device_get_subvendor_id(pci_dev);
-	pci_id->sub_dev_id = spdk_pci_device_get_subdevice_id(pci_dev);
+	*pci_id = spdk_pci_device_get_id(pci_dev);
 
 	return 0;
 }

--- a/lib/nvme/nvme_pcie.c
+++ b/lib/nvme/nvme_pcie.c
@@ -288,7 +288,7 @@ nvme_pcie_ctrlr_map_cmb(struct nvme_pcie_ctrlr *pctrlr)
 
 	if (nvme_pcie_ctrlr_get_cmbsz(pctrlr, &cmbsz) ||
 	    nvme_pcie_ctrlr_get_cmbloc(pctrlr, &cmbloc)) {
-		SPDK_TRACELOG(SPDK_TRACE_NVME, "get registers failed\n");
+		SPDK_ERRLOG("get registers failed\n");
 		goto exit;
 	}
 
@@ -346,7 +346,7 @@ nvme_pcie_ctrlr_unmap_cmb(struct nvme_pcie_ctrlr *pctrlr)
 
 	if (addr) {
 		if (nvme_pcie_ctrlr_get_cmbloc(pctrlr, &cmbloc)) {
-			SPDK_TRACELOG(SPDK_TRACE_NVME, "get_cmbloc() failed\n");
+			SPDK_ERRLOG("get_cmbloc() failed\n");
 			return -EIO;
 		}
 		rc = spdk_pci_device_unmap_bar(pctrlr->ctrlr.devhandle, cmbloc.bits.bir, addr);
@@ -460,7 +460,7 @@ static struct spdk_nvme_ctrlr *nvme_pcie_ctrlr_construct(void *devhandle)
 	spdk_pci_device_cfg_write32(pci_dev, cmd_reg, 4);
 
 	if (nvme_ctrlr_get_cap(&pctrlr->ctrlr, &cap)) {
-		SPDK_TRACELOG(SPDK_TRACE_NVME, "get_cap() failed\n");
+		SPDK_ERRLOG("get_cap() failed\n");
 		spdk_free(pctrlr);
 		return NULL;
 	}
@@ -507,12 +507,12 @@ nvme_pcie_ctrlr_enable(struct spdk_nvme_ctrlr *ctrlr)
 	union spdk_nvme_aqa_register aqa;
 
 	if (nvme_pcie_ctrlr_set_asq(pctrlr, padminq->cmd_bus_addr)) {
-		SPDK_TRACELOG(SPDK_TRACE_NVME, "set_asq() failed\n");
+		SPDK_ERRLOG("set_asq() failed\n");
 		return -EIO;
 	}
 
 	if (nvme_pcie_ctrlr_set_acq(pctrlr, padminq->cpl_bus_addr)) {
-		SPDK_TRACELOG(SPDK_TRACE_NVME, "set_acq() failed\n");
+		SPDK_ERRLOG("set_acq() failed\n");
 		return -EIO;
 	}
 
@@ -522,7 +522,7 @@ nvme_pcie_ctrlr_enable(struct spdk_nvme_ctrlr *ctrlr)
 	aqa.bits.asqs = ctrlr->adminq->num_entries - 1;
 
 	if (nvme_pcie_ctrlr_set_aqa(pctrlr, &aqa)) {
-		SPDK_TRACELOG(SPDK_TRACE_NVME, "set_aqa() failed\n");
+		SPDK_ERRLOG("set_aqa() failed\n");
 		return -EIO;
 	}
 
@@ -1175,7 +1175,7 @@ nvme_pcie_ctrlr_create_io_qpair(struct spdk_nvme_ctrlr *ctrlr, uint16_t qid,
 	rc = _nvme_pcie_ctrlr_create_io_qpair(ctrlr, qpair, qid);
 
 	if (rc != 0) {
-		SPDK_TRACELOG(SPDK_TRACE_NVME, "I/O queue creation failed\n");
+		SPDK_ERRLOG("I/O queue creation failed\n");
 		free(pqpair);
 		return NULL;
 	}

--- a/lib/nvme/nvme_qpair.c
+++ b/lib/nvme/nvme_qpair.c
@@ -351,7 +351,7 @@ nvme_qpair_construct(struct spdk_nvme_qpair *qpair, uint16_t id,
 	STAILQ_INIT(&qpair->queued_req);
 
 	if (qpair->transport->qpair_construct(qpair)) {
-		SPDK_TRACELOG(SPDK_TRACE_NVME, "qpair_construct() failed\n");
+		SPDK_ERRLOG("qpair_construct() failed\n");
 		nvme_qpair_destroy(qpair);
 		return -1;
 	}

--- a/lib/nvme/nvme_qpair.c
+++ b/lib/nvme/nvme_qpair.c
@@ -336,13 +336,14 @@ spdk_nvme_qpair_process_completions(struct spdk_nvme_qpair *qpair, uint32_t max_
 int
 nvme_qpair_construct(struct spdk_nvme_qpair *qpair, uint16_t id,
 		     uint16_t num_entries,
-		     struct spdk_nvme_ctrlr *ctrlr)
+		     struct spdk_nvme_ctrlr *ctrlr,
+		     enum spdk_nvme_qprio qprio)
 {
 	assert(num_entries != 0);
 
 	qpair->id = id;
 	qpair->num_entries = num_entries;
-	qpair->qprio = 0;
+	qpair->qprio = qprio;
 
 	qpair->ctrlr = ctrlr;
 	qpair->transport = ctrlr->transport;

--- a/lib/nvme/nvme_quirks.c
+++ b/lib/nvme/nvme_quirks.c
@@ -34,8 +34,8 @@
 #include "nvme_internal.h"
 
 struct nvme_quirk {
-	struct pci_id	id;
-	uint64_t	flags;
+	struct spdk_pci_id	id;
+	uint64_t		flags;
 };
 
 static const struct nvme_quirk nvme_quirks[] = {
@@ -51,19 +51,19 @@ static const struct nvme_quirk nvme_quirks[] = {
 
 /* Compare each field. SPDK_PCI_ANY_ID in s1 matches everything */
 static bool
-pci_id_match(const struct pci_id *s1, const struct pci_id *s2)
+pci_id_match(const struct spdk_pci_id *s1, const struct spdk_pci_id *s2)
 {
 	if ((s1->vendor_id == SPDK_PCI_ANY_ID || s1->vendor_id == s2->vendor_id) &&
-	    (s1->dev_id == SPDK_PCI_ANY_ID || s1->dev_id == s2->dev_id) &&
-	    (s1->sub_vendor_id == SPDK_PCI_ANY_ID || s1->sub_vendor_id == s2->sub_vendor_id) &&
-	    (s1->sub_dev_id == SPDK_PCI_ANY_ID || s1->sub_dev_id == s2->sub_dev_id)) {
+	    (s1->device_id == SPDK_PCI_ANY_ID || s1->device_id == s2->device_id) &&
+	    (s1->subvendor_id == SPDK_PCI_ANY_ID || s1->subvendor_id == s2->subvendor_id) &&
+	    (s1->subdevice_id == SPDK_PCI_ANY_ID || s1->subdevice_id == s2->subdevice_id)) {
 		return true;
 	}
 	return false;
 }
 
 uint64_t
-nvme_get_quirks(const struct pci_id *id)
+nvme_get_quirks(const struct spdk_pci_id *id)
 {
 	const struct nvme_quirk *quirk = nvme_quirks;
 

--- a/lib/nvmf/rdma.c
+++ b/lib/nvmf/rdma.c
@@ -996,7 +996,9 @@ spdk_nvmf_rdma_fini(void)
 		rdma_destroy_id(addr->id);
 	}
 
-	rdma_destroy_event_channel(g_rdma.event_channel);
+	if (g_rdma.event_channel != NULL) {
+		rdma_destroy_event_channel(g_rdma.event_channel);
+	}
 	pthread_mutex_unlock(&g_rdma.lock);
 
 	return 0;

--- a/lib/nvmf/rdma.c
+++ b/lib/nvmf/rdma.c
@@ -297,7 +297,8 @@ spdk_nvmf_rdma_conn_create(struct rdma_cm_id *id, struct ibv_comp_channel *chann
 					0);
 	rdma_conn->bufs_mr = ibv_reg_mr(id->pd, rdma_conn->bufs,
 					max_queue_depth * g_rdma.in_capsule_data_size,
-					IBV_ACCESS_LOCAL_WRITE);
+					IBV_ACCESS_LOCAL_WRITE |
+					IBV_ACCESS_REMOTE_WRITE);
 	if (!rdma_conn->cmds_mr || !rdma_conn->cpls_mr || !rdma_conn->bufs_mr) {
 		SPDK_ERRLOG("Unable to register required memory for RDMA queue.\n");
 		spdk_nvmf_rdma_conn_destroy(rdma_conn);
@@ -1250,7 +1251,8 @@ spdk_nvmf_rdma_session_add_conn(struct spdk_nvmf_session *session,
 	rdma_sess->verbs = rdma_conn->cm_id->verbs;
 	rdma_sess->buf_mr = ibv_reg_mr(rdma_conn->cm_id->pd, rdma_sess->buf,
 				       g_rdma.max_queue_depth * g_rdma.max_io_size,
-				       IBV_ACCESS_LOCAL_WRITE);
+				       IBV_ACCESS_LOCAL_WRITE |
+				       IBV_ACCESS_REMOTE_WRITE);
 	if (!rdma_sess->buf_mr) {
 		SPDK_ERRLOG("Large buffer pool registration failed (%d x %d)\n",
 			    g_rdma.max_queue_depth, g_rdma.max_io_size);

--- a/lib/nvmf/session.c
+++ b/lib/nvmf/session.c
@@ -331,7 +331,7 @@ spdk_nvmf_session_connect(struct spdk_nvmf_conn *conn,
 	conn->sess = session;
 
 	rsp->status.sc = SPDK_NVME_SC_SUCCESS;
-	rsp->status_code_specific.success.cntlid = 0;
+	rsp->status_code_specific.success.cntlid = session->vcdata.cntlid;
 	SPDK_TRACELOG(SPDK_TRACE_NVMF, "connect capsule response: cntlid = 0x%04x\n",
 		      rsp->status_code_specific.success.cntlid);
 }

--- a/lib/nvmf/subsystem.c
+++ b/lib/nvmf/subsystem.c
@@ -261,10 +261,10 @@ spdk_nvmf_subsystem_add_host(struct spdk_nvmf_subsystem *subsystem, char *host_n
 
 int
 nvmf_subsystem_add_ctrlr(struct spdk_nvmf_subsystem *subsystem,
-			 struct spdk_nvme_ctrlr *ctrlr, struct spdk_pci_device *dev)
+			 struct spdk_nvme_ctrlr *ctrlr, const struct spdk_pci_addr *pci_addr)
 {
 	subsystem->dev.direct.ctrlr = ctrlr;
-	subsystem->dev.direct.pci_dev = dev;
+	subsystem->dev.direct.pci_addr = *pci_addr;
 	/* Assume that all I/O will be handled on one thread for now */
 	subsystem->dev.direct.io_qpair = spdk_nvme_ctrlr_alloc_io_qpair(ctrlr, 0);
 	if (subsystem->dev.direct.io_qpair == NULL) {

--- a/lib/scsi/scsi_bdev.c
+++ b/lib/scsi/scsi_bdev.c
@@ -1304,7 +1304,6 @@ spdk_bdev_scsi_task_complete(spdk_event_t event)
 				asc  = SPDK_SCSI_ASC_NO_ADDITIONAL_SENSE;
 				ascq = SPDK_SCSI_ASCQ_CAUSE_NOT_REPORTABLE;
 				break;
-
 			}
 			spdk_scsi_task_set_status(task, sc, sk, asc, ascq);
 		}

--- a/lib/scsi/scsi_bdev.c
+++ b/lib/scsi/scsi_bdev.c
@@ -1283,23 +1283,30 @@ spdk_bdev_scsi_task_complete(spdk_event_t event)
 	enum spdk_bdev_io_status	status = bdev_io->status;
 
 	if (task->type == SPDK_SCSI_TASK_TYPE_CMD) {
-		int sc, sk, asc, ascq;
-
-		switch (bdev_io->status) {
-		case SPDK_BDEV_IO_STATUS_SUCCESS:
+		if (status == SPDK_BDEV_IO_STATUS_SUCCESS) {
 			task->status = SPDK_SCSI_STATUS_GOOD;
-			break;
-		case SPDK_BDEV_IO_STATUS_NVME_ERROR:
-			spdk_scsi_nvme_translate(bdev_io, &sc, &sk, &asc, &ascq);
+		} else {
+			int sc, sk, asc, ascq;
+
+			switch (status) {
+			case SPDK_BDEV_IO_STATUS_NVME_ERROR:
+				spdk_scsi_nvme_translate(bdev_io, &sc, &sk, &asc, &ascq);
+				break;
+			case SPDK_BDEV_IO_STATUS_SCSI_ERROR:
+				sc   = bdev_io->error.scsi.sc;
+				sk   = bdev_io->error.scsi.sk;
+				asc  = bdev_io->error.scsi.asc;
+				ascq = bdev_io->error.scsi.ascq;
+				break;
+			default:
+				sc   = SPDK_SCSI_STATUS_CHECK_CONDITION;
+				sk   = SPDK_SCSI_SENSE_ABORTED_COMMAND;
+				asc  = SPDK_SCSI_ASC_NO_ADDITIONAL_SENSE;
+				ascq = SPDK_SCSI_ASCQ_CAUSE_NOT_REPORTABLE;
+				break;
+
+			}
 			spdk_scsi_task_set_status(task, sc, sk, asc, ascq);
-			break;
-		default:
-			sc   = SPDK_SCSI_STATUS_CHECK_CONDITION;
-			sk   = SPDK_SCSI_SENSE_ABORTED_COMMAND;
-			asc  = SPDK_SCSI_ASC_NO_ADDITIONAL_SENSE;
-			ascq = SPDK_SCSI_ASCQ_CAUSE_NOT_REPORTABLE;
-			spdk_scsi_task_set_status(task, sc, sk, asc, ascq);
-			break;
 		}
 
 		/* command completed. remove from outstanding task list */

--- a/lib/scsi/scsi_bdev.c
+++ b/lib/scsi/scsi_bdev.c
@@ -1848,9 +1848,8 @@ spdk_bdev_scsi_process_primary(struct spdk_bdev *bdev,
 
 		spdk_scsi_task_build_sense_data(task, sk, asc, ascq);
 
-		/* omit SenseLength */
-		data_len = task->sense_data_len - 2;
-		memcpy(data, &task->sense_data[2], data_len);
+		data_len = task->sense_data_len;
+		memcpy(data, task->sense_data, data_len);
 		task->data_transferred = (uint64_t)data_len;
 		task->status = SPDK_SCSI_STATUS_GOOD;
 		break;

--- a/lib/scsi/task.c
+++ b/lib/scsi/task.c
@@ -133,18 +133,13 @@ spdk_scsi_task_alloc_data(struct spdk_scsi_task *task, uint32_t alloc_len,
 void
 spdk_scsi_task_build_sense_data(struct spdk_scsi_task *task, int sk, int asc, int ascq)
 {
-	uint8_t *data;
 	uint8_t *cp;
 	int resp_code;
 
-	data = task->sense_data;
 	resp_code = 0x70; /* Current + Fixed format */
 
-	/* SenseLength */
-	memset(data, 0, 2);
-
 	/* Sense Data */
-	cp = &data[2];
+	cp = task->sense_data;
 
 	/* VALID(7) RESPONSE CODE(6-0) */
 	cp[0] = 0x80 | resp_code;
@@ -173,8 +168,7 @@ spdk_scsi_task_build_sense_data(struct spdk_scsi_task *task, int sk, int asc, in
 	cp[17] = 0;
 
 	/* SenseLength */
-	to_be16(data, 18);
-	task->sense_data_len = 20;
+	task->sense_data_len = 18;
 }
 
 void

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -100,13 +100,13 @@ p.set_defaults(func=get_target_nodes)
 
 def construct_target_node(args):
     lun_name_id_dict = dict(u.split(":")
-                            for u in args.lun_name_id_pairs.split(" "))
+                            for u in args.lun_name_id_pairs.strip().split(" "))
     lun_names = lun_name_id_dict.keys()
     lun_ids = list(map(int, lun_name_id_dict.values()))
 
     pg_tags = []
     ig_tags = []
-    for u in args.pg_ig_mappings.split(" "):
+    for u in args.pg_ig_mappings.strip().split(" "):
         pg, ig = u.split(":")
         pg_tags.append(int(pg))
         ig_tags.append(int(ig))
@@ -236,9 +236,9 @@ p.set_defaults(func=add_portal_group)
 def add_initiator_group(args):
     initiators = []
     netmasks = []
-    for i in args.initiator_list.split(' '):
+    for i in args.initiator_list.strip().split(' '):
         initiators.append(i)
-    for n in args.netmask_list.split(' '):
+    for n in args.netmask_list.strip().split(' '):
         netmasks.append(n)
 
     params = {'tag': args.tag, 'initiators': initiators, 'netmasks': netmasks}
@@ -349,13 +349,13 @@ def construct_nvmf_subsystem(args):
 
     if args.hosts:
         hosts = []
-        for u in args.hosts.split(" "):
+        for u in args.hosts.strip().split(" "):
             hosts.append(u)
         params['hosts'] = hosts
 
     if args.namespaces:
         namespaces = []
-        for u in args.namespaces.split(" "):
+        for u in args.namespaces.strip().split(" "):
             namespaces.append(u)
         params['namespaces'] = namespaces
 

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -330,6 +330,12 @@ def get_interfaces(args):
 p = subparsers.add_parser('get_interfaces', help='Display current interface list')
 p.set_defaults(func=get_interfaces)
 
+def get_bdevs(args):
+    print_dict(jsonrpc_call('get_bdevs'))
+
+p = subparsers.add_parser('get_bdevs', help='Display current blockdev list')
+p.set_defaults(func=get_bdevs)
+
 def get_nvmf_subsystems(args):
     print_dict(jsonrpc_call('get_nvmf_subsystems'))
 

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -181,14 +181,14 @@ def construct_rbd_bdev(args):
     params = {
         'pool_name': args.pool_name,
         'rbd_name': args.rbd_name,
-        'size': args.size,
+        'block_size': args.block_size,
     }
     print_array(jsonrpc_call('construct_rbd_bdev', params))
 
 p = subparsers.add_parser('construct_rbd_bdev', help='Add a bdev with ceph rbd backend')
 p.add_argument('pool_name', help='rbd pool name')
 p.add_argument('rbd_name', help='rbd image name')
-p.add_argument('size', help='rbd block size', type=int)
+p.add_argument('block_size', help='rbd block size', type=int)
 p.set_defaults(func=construct_rbd_bdev)
 
 def set_trace_flag(args):

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -4,10 +4,18 @@ import argparse
 import json
 import socket
 
+try:
+    from shlex import quote
+except ImportError:
+    from pipes import quote
+
 SPDK_JSONRPC_PORT_BASE = 5260
 
 def print_dict(d):
     print json.dumps(d, indent=2)
+
+def print_array(a):
+    print " ".join((quote(v) for v in a))
 
 parser = argparse.ArgumentParser(description='SPDK RPC command line interface')
 parser.add_argument('-s', dest='server_ip', help='RPC server IP address', default='127.0.0.1')
@@ -146,7 +154,7 @@ p.set_defaults(func=construct_target_node)
 def construct_malloc_bdev(args):
     num_blocks = (args.total_size * 1024 * 1024) / args.block_size
     params = {'num_blocks': num_blocks, 'block_size': args.block_size}
-    jsonrpc_call('construct_malloc_bdev', params)
+    print_array(jsonrpc_call('construct_malloc_bdev', params))
 
 p = subparsers.add_parser('construct_malloc_bdev', help='Add a bdev with malloc backend')
 p.add_argument('total_size', help='Size of malloc bdev in MB (int > 0)', type=int)
@@ -156,7 +164,7 @@ p.set_defaults(func=construct_malloc_bdev)
 
 def construct_aio_bdev(args):
     params = {'fname': args.fname}
-    jsonrpc_call('construct_aio_bdev', params)
+    print_array(jsonrpc_call('construct_aio_bdev', params))
 
 p = subparsers.add_parser('construct_aio_bdev', help='Add a bdev with aio backend')
 p.add_argument('fname', help='Path to device or file (ex: /dev/sda)')
@@ -164,7 +172,7 @@ p.set_defaults(func=construct_aio_bdev)
 
 def construct_nvme_bdev(args):
     params = {'pci_address': args.pci_address}
-    jsonrpc_call('construct_nvme_bdev', params)
+    print_array(jsonrpc_call('construct_nvme_bdev', params))
 p = subparsers.add_parser('construct_nvme_bdev', help='Add bdev with nvme backend')
 p.add_argument('pci_address', help='PCI address domain:bus:device.function')
 p.set_defaults(func=construct_nvme_bdev)
@@ -175,7 +183,7 @@ def construct_rbd_bdev(args):
         'rbd_name': args.rbd_name,
         'size': args.size,
     }
-    jsonrpc_call('construct_rbd_bdev', params)
+    print_array(jsonrpc_call('construct_rbd_bdev', params))
 
 p = subparsers.add_parser('construct_rbd_bdev', help='Add a bdev with ceph rbd backend')
 p.add_argument('pool_name', help='rbd pool name')

--- a/test/iscsi_tgt/calsoft/calsoft.py
+++ b/test/iscsi_tgt/calsoft/calsoft.py
@@ -98,9 +98,13 @@ def main():
         exit(1)
     with open(output_file, 'w') as f:
         json.dump(obj=result, fp=f, indent=2)
-    if any(["FAIL" == x["Result"] for x in case_result_list]):
-        print "Test case %s failed." % (x["Name"])
-        sys.exit(1)
+
+    failed = 0
+    for x in case_result_list:
+        if x["Result"] == "FAIL":
+            print "Test case %s failed." % (x["Name"])
+            failed = 1
+    exit(failed)
 
 if __name__ == '__main__':
     main()

--- a/test/iscsi_tgt/rpc_config/rpc_config.py
+++ b/test/iscsi_tgt/rpc_config/rpc_config.py
@@ -400,14 +400,11 @@ def verify_add_nvme_bdev_rpc_methods(rpc_py):
     addrs = re.findall('^([0-9]{2}:[0-9]{2}.[0-9]) "Non-Volatile memory controller \[0108\]".*-p02', output, re.MULTILINE)
     for addr in addrs:
         ctrlr_address = "0000:{}".format(addr)
-        output = rpc.construct_nvme_bdev(ctrlr_address)
-        if output.strip() == '':
-            print "add nvme device passed first time"
-            test_pass = 1
-        verify(test_pass == 1, 1, "add nvme device passed first time")
+        rpc.construct_nvme_bdev(ctrlr_address)
+        print "add nvme device passed first time"
         test_pass = 0
         try:
-            output = rpc.construct_nvme_bdev(ctrlr_address)
+            rpc.construct_nvme_bdev(ctrlr_address)
         except Exception as e:
             print "add nvme device passed second time"
             test_pass = 1

--- a/test/lib/json/jsoncat/.gitignore
+++ b/test/lib/json/jsoncat/.gitignore
@@ -1,0 +1,1 @@
+jsoncat

--- a/test/lib/json/jsoncat/Makefile
+++ b/test/lib/json/jsoncat/Makefile
@@ -31,14 +31,23 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-SPDK_ROOT_DIR := $(abspath $(CURDIR)/../../..)
+SPDK_ROOT_DIR := $(abspath $(CURDIR)/../../../..)
 include $(SPDK_ROOT_DIR)/mk/spdk.common.mk
 
-DIRS-y = jsoncat parse util write
+APP = jsoncat
 
-.PHONY: all clean $(DIRS-y)
+C_SRCS = jsoncat.c
 
-all: $(DIRS-y)
-clean: $(DIRS-y)
+SPDK_LIBS += $(SPDK_ROOT_DIR)/lib/json/libspdk_json.a
 
-include $(SPDK_ROOT_DIR)/mk/spdk.subdirs.mk
+LIBS += $(SPDK_LIBS)
+
+all: $(APP)
+
+$(APP): $(OBJS) $(SPDK_LIBS)
+	$(LINK_C)
+
+clean:
+	$(CLEAN_C) $(APP)
+
+include $(SPDK_ROOT_DIR)/mk/spdk.deps.mk

--- a/test/lib/json/jsoncat/jsoncat.c
+++ b/test/lib/json/jsoncat/jsoncat.c
@@ -1,0 +1,231 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright (c) Intel Corporation.
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Simple JSON "cat" utility */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "spdk/json.h"
+
+static void
+usage(const char *prog)
+{
+	printf("usage: %s [-c] [-f] file.json\n", prog);
+	printf("Options:\n");
+	printf("-c\tallow comments in input (non-standard)\n");
+	printf("-f\tformatted output (default: compact output)\n");
+}
+
+static void
+print_json_error(FILE *pf, int rc, const char *filename)
+{
+	switch (rc) {
+	case SPDK_JSON_PARSE_INVALID:
+		fprintf(pf, "%s: invalid JSON\n", filename);
+		break;
+	case SPDK_JSON_PARSE_INCOMPLETE:
+		fprintf(pf, "%s: incomplete JSON\n", filename);
+		break;
+	case SPDK_JSON_PARSE_MAX_DEPTH_EXCEEDED:
+		fprintf(pf, "%s: maximum nesting depth exceeded\n", filename);
+		break;
+	default:
+		fprintf(pf, "%s: unknown JSON parse error\n", filename);
+		break;
+	}
+}
+
+static int
+json_write_cb(void *cb_ctx, const void *data, size_t size)
+{
+	FILE *f = cb_ctx;
+	size_t rc;
+
+	rc = fwrite(data, 1, size, f);
+	return rc == size ? 0 : -1;
+}
+
+static void *
+read_file(FILE *f, size_t *psize)
+{
+	void *buf, *newbuf;
+	size_t cur_size, buf_size, rc;
+
+	buf = NULL;
+	cur_size = 0;
+	buf_size = 128 * 1024;
+
+	while (buf_size <= 1024 * 1024 * 1024) {
+		newbuf = realloc(buf, buf_size);
+		if (newbuf == NULL) {
+			free(buf);
+			return NULL;
+		}
+		buf = newbuf;
+
+		rc = fread(buf + cur_size, 1, buf_size - cur_size, f);
+		cur_size += rc;
+
+		if (feof(f)) {
+			*psize = cur_size;
+			return buf;
+		}
+
+		if (ferror(f)) {
+			free(buf);
+			return NULL;
+		}
+
+		buf_size *= 2;
+	}
+
+	free(buf);
+	return NULL;
+}
+
+static int
+process_file(const char *filename, FILE *f, uint32_t parse_flags, uint32_t write_flags)
+{
+	size_t size;
+	void *buf, *end;
+	ssize_t rc;
+	struct spdk_json_val *values;
+	size_t num_values;
+	struct spdk_json_write_ctx *w;
+
+	buf = read_file(f, &size);
+	if (buf == NULL) {
+		fprintf(stderr, "%s: file read error\n", filename);
+		return 1;
+	}
+
+	rc = spdk_json_parse(buf, size, NULL, 0, NULL, parse_flags);
+	if (rc <= 0) {
+		print_json_error(stderr, rc, filename);
+		free(buf);
+		return 1;
+	}
+
+	num_values = (size_t)rc;
+	values = calloc(num_values, sizeof(*values));
+	if (values == NULL) {
+		perror("values calloc");
+		free(buf);
+		return 1;
+	}
+
+	rc = spdk_json_parse(buf, size, values, num_values, &end,
+			     parse_flags | SPDK_JSON_PARSE_FLAG_DECODE_IN_PLACE);
+	if (rc <= 0) {
+		print_json_error(stderr, rc, filename);
+		free(values);
+		free(buf);
+		return 1;
+	}
+
+	w = spdk_json_write_begin(json_write_cb, stdout, write_flags);
+	if (w == NULL) {
+		fprintf(stderr, "json_write_begin failed\n");
+		free(values);
+		free(buf);
+		return 1;
+	}
+
+	spdk_json_write_val(w, values);
+	spdk_json_write_end(w);
+	printf("\n");
+
+	if (end != buf + size) {
+		fprintf(stderr, "%s: garbage at end of file\n", filename);
+		free(values);
+		free(buf);
+		return 1;
+	}
+
+	free(values);
+	free(buf);
+	return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+	FILE *f;
+	int ch;
+	int rc;
+	uint32_t parse_flags = 0, write_flags = 0;
+	const char *filename;
+
+	while ((ch = getopt(argc, argv, "cf")) != -1) {
+		switch (ch) {
+		case 'c':
+			parse_flags |= SPDK_JSON_PARSE_FLAG_ALLOW_COMMENTS;
+			break;
+		case 'f':
+			write_flags |= SPDK_JSON_WRITE_FLAG_FORMATTED;
+			break;
+		default:
+			usage(argv[0]);
+			return 1;
+		}
+	}
+
+	if (optind == argc) {
+		filename = "-";
+	} else if (optind == argc - 1) {
+		filename = argv[optind];
+	} else {
+		usage(argv[0]);
+		return 1;
+	}
+
+	if (strcmp(filename, "-") == 0) {
+		f = stdin;
+	} else {
+		f = fopen(filename, "r");
+		if (f == NULL) {
+			perror("fopen");
+			return 1;
+		}
+	}
+
+	rc = process_file(filename, f, parse_flags, write_flags);
+
+	if (f != stdin) {
+		fclose(f);
+	}
+
+	return rc;
+}

--- a/test/lib/nvme/e2edp/nvme_dp.c
+++ b/test/lib/nvme/e2edp/nvme_dp.c
@@ -606,20 +606,21 @@ write_read_e2e_dp_tests(struct dev *dev, nvme_build_io_req_fn_t build_io_fn, con
 }
 
 static bool
-probe_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr_opts *opts)
+probe_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	 struct spdk_nvme_ctrlr_opts *opts)
 {
 	printf("Attaching to %04x:%02x:%02x.%02x\n",
-	       spdk_pci_device_get_domain(dev),
-	       spdk_pci_device_get_bus(dev),
-	       spdk_pci_device_get_dev(dev),
-	       spdk_pci_device_get_func(dev));
+	       probe_info->pci_addr.domain,
+	       probe_info->pci_addr.bus,
+	       probe_info->pci_addr.dev,
+	       probe_info->pci_addr.func);
 
 	return true;
 }
 
 static void
-attach_cb(void *cb_ctx, struct spdk_pci_device *pci_dev, struct spdk_nvme_ctrlr *ctrlr,
-	  const struct spdk_nvme_ctrlr_opts *opts)
+attach_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	  struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *opts)
 {
 	struct dev *dev;
 
@@ -629,10 +630,10 @@ attach_cb(void *cb_ctx, struct spdk_pci_device *pci_dev, struct spdk_nvme_ctrlr 
 	dev->ctrlr = ctrlr;
 
 	snprintf(dev->name, sizeof(dev->name), "%04X:%02X:%02X.%02X",
-		 spdk_pci_device_get_domain(pci_dev),
-		 spdk_pci_device_get_bus(pci_dev),
-		 spdk_pci_device_get_dev(pci_dev),
-		 spdk_pci_device_get_func(pci_dev));
+		 probe_info->pci_addr.domain,
+		 probe_info->pci_addr.bus,
+		 probe_info->pci_addr.dev,
+		 probe_info->pci_addr.func);
 
 	printf("Attached to %s\n", dev->name);
 }

--- a/test/lib/nvme/overhead/overhead.c
+++ b/test/lib/nvme/overhead/overhead.c
@@ -530,39 +530,40 @@ parse_args(int argc, char **argv)
 }
 
 static bool
-probe_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr_opts *opts)
+probe_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	 struct spdk_nvme_ctrlr_opts *opts)
 {
 	static uint32_t ctrlr_found = 0;
 
 	if (ctrlr_found == 1) {
 		fprintf(stderr, "only attching to one controller, so skipping\n");
 		fprintf(stderr, " controller at PCI address %04x:%02x:%02x.%02x\n",
-			spdk_pci_device_get_domain(dev),
-			spdk_pci_device_get_bus(dev),
-			spdk_pci_device_get_dev(dev),
-			spdk_pci_device_get_func(dev));
+			probe_info->pci_addr.domain,
+			probe_info->pci_addr.bus,
+			probe_info->pci_addr.dev,
+			probe_info->pci_addr.func);
 		return false;
 	}
 	ctrlr_found = 1;
 
 	printf("Attaching to %04x:%02x:%02x.%02x\n",
-	       spdk_pci_device_get_domain(dev),
-	       spdk_pci_device_get_bus(dev),
-	       spdk_pci_device_get_dev(dev),
-	       spdk_pci_device_get_func(dev));
+	       probe_info->pci_addr.domain,
+	       probe_info->pci_addr.bus,
+	       probe_info->pci_addr.dev,
+	       probe_info->pci_addr.func);
 
 	return true;
 }
 
 static void
-attach_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr *ctrlr,
-	  const struct spdk_nvme_ctrlr_opts *opts)
+attach_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	  struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *opts)
 {
 	printf("Attached to %04x:%02x:%02x.%02x\n",
-	       spdk_pci_device_get_domain(dev),
-	       spdk_pci_device_get_bus(dev),
-	       spdk_pci_device_get_dev(dev),
-	       spdk_pci_device_get_func(dev));
+	       probe_info->pci_addr.domain,
+	       probe_info->pci_addr.bus,
+	       probe_info->pci_addr.dev,
+	       probe_info->pci_addr.func);
 
 	register_ctrlr(ctrlr);
 }

--- a/test/lib/nvme/reset/reset.c
+++ b/test/lib/nvme/reset/reset.c
@@ -508,14 +508,15 @@ register_workers(void)
 
 
 static bool
-probe_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr_opts *opts)
+probe_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	 struct spdk_nvme_ctrlr_opts *opts)
 {
 	return true;
 }
 
 static void
-attach_cb(void *cb_ctx, struct spdk_pci_device *pci_dev, struct spdk_nvme_ctrlr *ctrlr,
-	  const struct spdk_nvme_ctrlr_opts *opts)
+attach_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	  struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *opts)
 {
 	register_ctrlr(ctrlr);
 }

--- a/test/lib/nvme/sgl/nvme_sgl.c
+++ b/test/lib/nvme/sgl/nvme_sgl.c
@@ -382,20 +382,21 @@ writev_readv_tests(struct dev *dev, nvme_build_io_req_fn_t build_io_fn, const ch
 }
 
 static bool
-probe_cb(void *cb_ctx, struct spdk_pci_device *dev, struct spdk_nvme_ctrlr_opts *opts)
+probe_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	 struct spdk_nvme_ctrlr_opts *opts)
 {
 	printf("Attaching to %04x:%02x:%02x.%02x\n",
-	       spdk_pci_device_get_domain(dev),
-	       spdk_pci_device_get_bus(dev),
-	       spdk_pci_device_get_dev(dev),
-	       spdk_pci_device_get_func(dev));
+	       probe_info->pci_addr.domain,
+	       probe_info->pci_addr.bus,
+	       probe_info->pci_addr.dev,
+	       probe_info->pci_addr.func);
 
 	return true;
 }
 
 static void
-attach_cb(void *cb_ctx, struct spdk_pci_device *pci_dev, struct spdk_nvme_ctrlr *ctrlr,
-	  const struct spdk_nvme_ctrlr_opts *opts)
+attach_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
+	  struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *opts)
 {
 	struct dev *dev;
 
@@ -405,10 +406,10 @@ attach_cb(void *cb_ctx, struct spdk_pci_device *pci_dev, struct spdk_nvme_ctrlr 
 	dev->ctrlr = ctrlr;
 
 	snprintf(dev->name, sizeof(dev->name), "%04X:%02X:%02X.%02X",
-		 spdk_pci_device_get_domain(pci_dev),
-		 spdk_pci_device_get_bus(pci_dev),
-		 spdk_pci_device_get_dev(pci_dev),
-		 spdk_pci_device_get_func(pci_dev));
+		 probe_info->pci_addr.domain,
+		 probe_info->pci_addr.bus,
+		 probe_info->pci_addr.dev,
+		 probe_info->pci_addr.func);
 
 	printf("Attached to %s\n", dev->name);
 }

--- a/test/lib/nvme/unit/nvme_c/nvme_ut.c
+++ b/test/lib/nvme/unit/nvme_c/nvme_ut.c
@@ -56,6 +56,12 @@ nvme_ctrlr_destruct(struct spdk_nvme_ctrlr *ctrlr)
 }
 
 int
+nvme_ctrlr_add_process(struct spdk_nvme_ctrlr *ctrlr, void *devhandle)
+{
+	return 0;
+}
+
+int
 nvme_ctrlr_process_init(struct spdk_nvme_ctrlr *ctrlr)
 {
 	return 0;

--- a/test/lib/nvme/unit/nvme_c/nvme_ut.c
+++ b/test/lib/nvme/unit/nvme_c/nvme_ut.c
@@ -50,6 +50,16 @@ spdk_pci_enumerate(enum spdk_pci_device_type type,
 	return -1;
 }
 
+struct spdk_pci_id
+spdk_pci_device_get_id(struct spdk_pci_device *pci_dev)
+{
+	struct spdk_pci_id pci_id;
+
+	memset(&pci_id, 0xFF, sizeof(pci_id));
+
+	return pci_id;
+}
+
 void
 nvme_ctrlr_destruct(struct spdk_nvme_ctrlr *ctrlr)
 {

--- a/test/lib/nvme/unit/nvme_c/nvme_ut.c
+++ b/test/lib/nvme/unit/nvme_c/nvme_ut.c
@@ -73,8 +73,17 @@ spdk_nvme_ctrlr_opts_set_defaults(struct spdk_nvme_ctrlr_opts *opts)
 	memset(opts, 0, sizeof(*opts));
 }
 
-bool
-spdk_pci_device_compare_addr(struct spdk_pci_device *dev, struct spdk_pci_addr *addr)
+struct spdk_pci_addr
+spdk_pci_device_get_addr(struct spdk_pci_device *pci_dev)
+{
+	struct spdk_pci_addr pci_addr;
+
+	memset(&pci_addr, 0, sizeof(pci_addr));
+	return pci_addr;
+}
+
+int
+spdk_pci_addr_compare(const struct spdk_pci_addr *a1, const struct spdk_pci_addr *a2)
 {
 	return true;
 }

--- a/test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
+++ b/test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
@@ -197,6 +197,24 @@ fake_cpl_success(spdk_nvme_cmd_cb cb_fn, void *cb_arg)
 }
 
 int
+spdk_nvme_ctrlr_cmd_set_feature(struct spdk_nvme_ctrlr *ctrlr, uint8_t feature,
+				uint32_t cdw11, uint32_t cdw12, void *payload, uint32_t payload_size,
+				spdk_nvme_cmd_cb cb_fn, void *cb_arg)
+{
+	CU_ASSERT_FATAL(0);
+	return -1;
+}
+
+int
+spdk_nvme_ctrlr_cmd_get_feature(struct spdk_nvme_ctrlr *ctrlr, uint8_t feature,
+				uint32_t cdw11, void *payload, uint32_t payload_size,
+				spdk_nvme_cmd_cb cb_fn, void *cb_arg)
+{
+	CU_ASSERT_FATAL(0);
+	return -1;
+}
+
+int
 spdk_nvme_ctrlr_cmd_get_log_page(struct spdk_nvme_ctrlr *ctrlr, uint8_t log_page,
 				 uint32_t nsid, void *payload, uint32_t payload_size, spdk_nvme_cmd_cb cb_fn,
 				 void *cb_arg)

--- a/test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
+++ b/test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
@@ -177,11 +177,12 @@ static const struct spdk_nvme_transport nvme_ctrlr_ut_transport = {
 
 int nvme_qpair_construct(struct spdk_nvme_qpair *qpair, uint16_t id,
 			 uint16_t num_entries,
-			 struct spdk_nvme_ctrlr *ctrlr)
+			 struct spdk_nvme_ctrlr *ctrlr,
+			 enum spdk_nvme_qprio qprio)
 {
 	qpair->id = id;
 	qpair->num_entries = num_entries;
-	qpair->qprio = 0;
+	qpair->qprio = qprio;
 	qpair->ctrlr = ctrlr;
 
 	return 0;

--- a/test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
+++ b/test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
@@ -376,6 +376,7 @@ nvme_allocate_request(const struct nvme_payload *payload, uint32_t payload_size,
 
 		req->cb_fn = cb_fn;
 		req->cb_arg = cb_arg;
+		req->pid = getpid();
 	}
 
 	return req;
@@ -525,6 +526,9 @@ test_nvme_ctrlr_init_en_0_rdy_0_ams_rr(void)
 	CU_ASSERT(g_ut_nvme_regs.cc.bits.ams == SPDK_NVME_CC_AMS_RR);
 	CU_ASSERT(ctrlr.opts.arb_mechanism == SPDK_NVME_CC_AMS_RR);
 
+	/*
+	 * Complete and destroy the controller
+	 */
 	g_ut_nvme_regs.csts.bits.shst = SPDK_NVME_SHST_COMPLETE;
 	nvme_ctrlr_destruct(&ctrlr);
 
@@ -546,6 +550,9 @@ test_nvme_ctrlr_init_en_0_rdy_0_ams_rr(void)
 	CU_ASSERT(ctrlr.state == NVME_CTRLR_STATE_ENABLE_WAIT_FOR_READY_1);
 	CU_ASSERT(g_ut_nvme_regs.cc.bits.en == 0);
 
+	/*
+	 * Complete and destroy the controller
+	 */
 	g_ut_nvme_regs.csts.bits.shst = SPDK_NVME_SHST_COMPLETE;
 	nvme_ctrlr_destruct(&ctrlr);
 
@@ -567,6 +574,9 @@ test_nvme_ctrlr_init_en_0_rdy_0_ams_rr(void)
 	CU_ASSERT(ctrlr.state == NVME_CTRLR_STATE_ENABLE_WAIT_FOR_READY_1);
 	CU_ASSERT(g_ut_nvme_regs.cc.bits.en == 0);
 
+	/*
+	 * Complete and destroy the controller
+	 */
 	g_ut_nvme_regs.csts.bits.shst = SPDK_NVME_SHST_COMPLETE;
 	nvme_ctrlr_destruct(&ctrlr);
 
@@ -588,6 +598,9 @@ test_nvme_ctrlr_init_en_0_rdy_0_ams_rr(void)
 	CU_ASSERT(ctrlr.state == NVME_CTRLR_STATE_ENABLE_WAIT_FOR_READY_1);
 	CU_ASSERT(g_ut_nvme_regs.cc.bits.en == 0);
 
+	/*
+	 * Complete and destroy the controller
+	 */
 	g_ut_nvme_regs.csts.bits.shst = SPDK_NVME_SHST_COMPLETE;
 	nvme_ctrlr_destruct(&ctrlr);
 
@@ -657,6 +670,9 @@ test_nvme_ctrlr_init_en_0_rdy_0_ams_wrr(void)
 	CU_ASSERT(g_ut_nvme_regs.cc.bits.ams == SPDK_NVME_CC_AMS_RR);
 	CU_ASSERT(ctrlr.opts.arb_mechanism == SPDK_NVME_CC_AMS_RR);
 
+	/*
+	 * Complete and destroy the controller
+	 */
 	g_ut_nvme_regs.csts.bits.shst = SPDK_NVME_SHST_COMPLETE;
 	nvme_ctrlr_destruct(&ctrlr);
 
@@ -680,6 +696,9 @@ test_nvme_ctrlr_init_en_0_rdy_0_ams_wrr(void)
 	CU_ASSERT(g_ut_nvme_regs.cc.bits.ams == SPDK_NVME_CC_AMS_WRR);
 	CU_ASSERT(ctrlr.opts.arb_mechanism == SPDK_NVME_CC_AMS_WRR);
 
+	/*
+	 * Complete and destroy the controller
+	 */
 	g_ut_nvme_regs.csts.bits.shst = SPDK_NVME_SHST_COMPLETE;
 	nvme_ctrlr_destruct(&ctrlr);
 
@@ -701,6 +720,9 @@ test_nvme_ctrlr_init_en_0_rdy_0_ams_wrr(void)
 	CU_ASSERT(ctrlr.state == NVME_CTRLR_STATE_ENABLE_WAIT_FOR_READY_1);
 	CU_ASSERT(g_ut_nvme_regs.cc.bits.en == 0);
 
+	/*
+	 * Complete and destroy the controller
+	 */
 	g_ut_nvme_regs.csts.bits.shst = SPDK_NVME_SHST_COMPLETE;
 	nvme_ctrlr_destruct(&ctrlr);
 
@@ -722,6 +744,9 @@ test_nvme_ctrlr_init_en_0_rdy_0_ams_wrr(void)
 	CU_ASSERT(ctrlr.state == NVME_CTRLR_STATE_ENABLE_WAIT_FOR_READY_1);
 	CU_ASSERT(g_ut_nvme_regs.cc.bits.en == 0);
 
+	/*
+	 * Complete and destroy the controller
+	 */
 	g_ut_nvme_regs.csts.bits.shst = SPDK_NVME_SHST_COMPLETE;
 	nvme_ctrlr_destruct(&ctrlr);
 
@@ -790,6 +815,9 @@ test_nvme_ctrlr_init_en_0_rdy_0_ams_vs(void)
 	CU_ASSERT(g_ut_nvme_regs.cc.bits.ams == SPDK_NVME_CC_AMS_RR);
 	CU_ASSERT(ctrlr.opts.arb_mechanism == SPDK_NVME_CC_AMS_RR);
 
+	/*
+	 * Complete and destroy the controller
+	 */
 	g_ut_nvme_regs.csts.bits.shst = SPDK_NVME_SHST_COMPLETE;
 	nvme_ctrlr_destruct(&ctrlr);
 
@@ -811,6 +839,9 @@ test_nvme_ctrlr_init_en_0_rdy_0_ams_vs(void)
 	CU_ASSERT(ctrlr.state == NVME_CTRLR_STATE_ENABLE_WAIT_FOR_READY_1);
 	CU_ASSERT(g_ut_nvme_regs.cc.bits.en == 0);
 
+	/*
+	 * Complete and destroy the controller
+	 */
 	g_ut_nvme_regs.csts.bits.shst = SPDK_NVME_SHST_COMPLETE;
 	nvme_ctrlr_destruct(&ctrlr);
 
@@ -834,6 +865,9 @@ test_nvme_ctrlr_init_en_0_rdy_0_ams_vs(void)
 	CU_ASSERT(g_ut_nvme_regs.cc.bits.ams == SPDK_NVME_CC_AMS_VS);
 	CU_ASSERT(ctrlr.opts.arb_mechanism == SPDK_NVME_CC_AMS_VS);
 
+	/*
+	 * Complete and destroy the controller
+	 */
 	g_ut_nvme_regs.csts.bits.shst = SPDK_NVME_SHST_COMPLETE;
 	nvme_ctrlr_destruct(&ctrlr);
 
@@ -855,6 +889,9 @@ test_nvme_ctrlr_init_en_0_rdy_0_ams_vs(void)
 	CU_ASSERT(ctrlr.state == NVME_CTRLR_STATE_ENABLE_WAIT_FOR_READY_1);
 	CU_ASSERT(g_ut_nvme_regs.cc.bits.en == 0);
 
+	/*
+	 * Complete and destroy the controller
+	 */
 	g_ut_nvme_regs.csts.bits.shst = SPDK_NVME_SHST_COMPLETE;
 	nvme_ctrlr_destruct(&ctrlr);
 

--- a/test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
+++ b/test/lib/nvme/unit/nvme_ctrlr_c/nvme_ctrlr_ut.c
@@ -74,16 +74,16 @@ ut_ctrlr_enable(struct spdk_nvme_ctrlr *ctrlr)
 }
 
 static int
-ut_ctrlr_get_pci_id(struct spdk_nvme_ctrlr *ctrlr, struct pci_id *pci_id)
+ut_ctrlr_get_pci_id(struct spdk_nvme_ctrlr *ctrlr, struct spdk_pci_id *pci_id)
 {
 	if (ctrlr == NULL || pci_id == NULL) {
 		return -EINVAL;
 	}
 
 	pci_id->vendor_id = g_pci_vendor_id;
-	pci_id->dev_id = g_pci_device_id;
-	pci_id->sub_vendor_id = g_pci_subvendor_id;
-	pci_id->sub_dev_id = g_pci_subdevice_id;
+	pci_id->device_id = g_pci_device_id;
+	pci_id->subvendor_id = g_pci_subvendor_id;
+	pci_id->subdevice_id = g_pci_subdevice_id;
 
 	return 0;
 }
@@ -1156,7 +1156,7 @@ test_nvme_ctrlr_construct_intel_support_log_page_list(void)
 	bool	res;
 	struct spdk_nvme_ctrlr				ctrlr = {};
 	struct spdk_nvme_intel_log_page_directory	payload = {};
-	struct pci_id					pci_id;
+	struct spdk_pci_id				pci_id;
 
 	ctrlr.transport = &nvme_ctrlr_ut_transport;
 

--- a/test/lib/nvme/unit/nvme_ctrlr_cmd_c/nvme_ctrlr_cmd_ut.c
+++ b/test/lib/nvme/unit/nvme_ctrlr_cmd_c/nvme_ctrlr_cmd_ut.c
@@ -253,6 +253,8 @@ nvme_allocate_request(const struct nvme_payload *payload, uint32_t payload_size,
 	req->cb_fn = cb_fn;
 	req->cb_arg = cb_arg;
 
+	req->pid = getpid();
+
 	return req;
 }
 

--- a/test/lib/nvme/unit/nvme_ns_cmd_c/nvme_ns_cmd_ut.c
+++ b/test/lib/nvme/unit/nvme_ns_cmd_c/nvme_ns_cmd_ut.c
@@ -77,8 +77,17 @@ nvme_ctrlr_start(struct spdk_nvme_ctrlr *ctrlr)
 	return 0;
 }
 
-bool
-spdk_pci_device_compare_addr(struct spdk_pci_device *dev, struct spdk_pci_addr *addr)
+struct spdk_pci_addr
+spdk_pci_device_get_addr(struct spdk_pci_device *pci_dev)
+{
+	struct spdk_pci_addr pci_addr;
+
+	memset(&pci_addr, 0, sizeof(pci_addr));
+	return pci_addr;
+}
+
+int
+spdk_pci_addr_compare(const struct spdk_pci_addr *a1, const struct spdk_pci_addr *a2)
 {
 	return true;
 }

--- a/test/lib/nvme/unit/nvme_ns_cmd_c/nvme_ns_cmd_ut.c
+++ b/test/lib/nvme/unit/nvme_ns_cmd_c/nvme_ns_cmd_ut.c
@@ -92,6 +92,16 @@ spdk_pci_device_get_addr(struct spdk_pci_device *pci_dev)
 	return pci_addr;
 }
 
+struct spdk_pci_id
+spdk_pci_device_get_id(struct spdk_pci_device *pci_dev)
+{
+	struct spdk_pci_id pci_id;
+
+	memset(&pci_id, 0xFF, sizeof(pci_id));
+
+	return pci_id;
+}
+
 int
 spdk_pci_addr_compare(const struct spdk_pci_addr *a1, const struct spdk_pci_addr *a2)
 {

--- a/test/lib/nvme/unit/nvme_ns_cmd_c/nvme_ns_cmd_ut.c
+++ b/test/lib/nvme/unit/nvme_ns_cmd_c/nvme_ns_cmd_ut.c
@@ -66,6 +66,12 @@ nvme_ctrlr_destruct(struct spdk_nvme_ctrlr *ctrlr)
 }
 
 int
+nvme_ctrlr_add_process(struct spdk_nvme_ctrlr *ctrlr, void *devhandle)
+{
+	return 0;
+}
+
+int
 nvme_ctrlr_process_init(struct spdk_nvme_ctrlr *ctrlr)
 {
 	return 0;

--- a/test/lib/nvme/unit/nvme_qpair_c/nvme_qpair_ut.c
+++ b/test/lib/nvme/unit/nvme_qpair_c/nvme_qpair_ut.c
@@ -223,7 +223,7 @@ prepare_submit_request_test(struct spdk_nvme_qpair *qpair,
 	ctrlr->transport = &nvme_qpair_ut_transport;
 	ctrlr->free_io_qids = NULL;
 	TAILQ_INIT(&ctrlr->active_io_qpairs);
-	nvme_qpair_construct(qpair, 1, 128, ctrlr);
+	nvme_qpair_construct(qpair, 1, 128, ctrlr, 0);
 
 	ut_fail_vtophys = false;
 }

--- a/test/lib/nvme/unit/nvme_qpair_c/nvme_qpair_ut.c
+++ b/test/lib/nvme/unit/nvme_qpair_c/nvme_qpair_ut.c
@@ -146,6 +146,7 @@ nvme_allocate_request(const struct nvme_payload *payload, uint32_t payload_size,
 	req->cb_arg = cb_arg;
 	req->payload = *payload;
 	req->payload_size = payload_size;
+	req->pid = getpid();
 
 	return req;
 }
@@ -223,6 +224,7 @@ prepare_submit_request_test(struct spdk_nvme_qpair *qpair,
 	ctrlr->transport = &nvme_qpair_ut_transport;
 	ctrlr->free_io_qids = NULL;
 	TAILQ_INIT(&ctrlr->active_io_qpairs);
+	TAILQ_INIT(&ctrlr->active_procs);
 	nvme_qpair_construct(qpair, 1, 128, ctrlr, 0);
 
 	ut_fail_vtophys = false;
@@ -581,6 +583,7 @@ static void test_nvme_qpair_destroy(void)
 	memset(&ctrlr, 0, sizeof(ctrlr));
 	TAILQ_INIT(&ctrlr.free_io_qpairs);
 	TAILQ_INIT(&ctrlr.active_io_qpairs);
+	TAILQ_INIT(&ctrlr.active_procs);
 
 	nvme_qpair_construct(&qpair, 1, 128, &ctrlr);
 	nvme_qpair_destroy(&qpair);

--- a/test/lib/scsi/scsi_bdev/scsi_bdev_ut.c
+++ b/test/lib/scsi/scsi_bdev/scsi_bdev_ut.c
@@ -489,6 +489,17 @@ task_complete_test(void)
 	spdk_bdev_scsi_task_complete(&event);
 	CU_ASSERT_EQUAL(task.status, SPDK_SCSI_STATUS_GOOD);
 
+	bdev_io.status = SPDK_BDEV_IO_STATUS_SCSI_ERROR;
+	bdev_io.error.scsi.sc = SPDK_SCSI_STATUS_CHECK_CONDITION;
+	bdev_io.error.scsi.sk = SPDK_SCSI_SENSE_HARDWARE_ERROR;
+	bdev_io.error.scsi.asc = SPDK_SCSI_ASC_WARNING;
+	bdev_io.error.scsi.ascq = SPDK_SCSI_ASCQ_POWER_LOSS_EXPECTED;
+	spdk_bdev_scsi_task_complete(&event);
+	CU_ASSERT_EQUAL(task.status, SPDK_SCSI_STATUS_CHECK_CONDITION);
+	CU_ASSERT_EQUAL(task.sense_data[4], SPDK_SCSI_SENSE_HARDWARE_ERROR);
+	CU_ASSERT_EQUAL(task.sense_data[14], SPDK_SCSI_ASC_WARNING);
+	CU_ASSERT_EQUAL(task.sense_data[15], SPDK_SCSI_ASCQ_POWER_LOSS_EXPECTED);
+
 	bdev_io.status = SPDK_BDEV_IO_STATUS_FAILED;
 	spdk_bdev_scsi_task_complete(&event);
 	CU_ASSERT_EQUAL(task.status, SPDK_SCSI_STATUS_CHECK_CONDITION);

--- a/test/lib/scsi/scsi_bdev/scsi_bdev_ut.c
+++ b/test/lib/scsi/scsi_bdev/scsi_bdev_ut.c
@@ -490,14 +490,14 @@ task_complete_test(void)
 	bdev_io.error.scsi.ascq = SPDK_SCSI_ASCQ_POWER_LOSS_EXPECTED;
 	spdk_bdev_scsi_task_complete(&event);
 	CU_ASSERT_EQUAL(task.status, SPDK_SCSI_STATUS_CHECK_CONDITION);
-	CU_ASSERT_EQUAL(task.sense_data[4], SPDK_SCSI_SENSE_HARDWARE_ERROR);
-	CU_ASSERT_EQUAL(task.sense_data[14], SPDK_SCSI_ASC_WARNING);
-	CU_ASSERT_EQUAL(task.sense_data[15], SPDK_SCSI_ASCQ_POWER_LOSS_EXPECTED);
+	CU_ASSERT_EQUAL(task.sense_data[2] & 0xf, SPDK_SCSI_SENSE_HARDWARE_ERROR);
+	CU_ASSERT_EQUAL(task.sense_data[12], SPDK_SCSI_ASC_WARNING);
+	CU_ASSERT_EQUAL(task.sense_data[13], SPDK_SCSI_ASCQ_POWER_LOSS_EXPECTED);
 
 	bdev_io.status = SPDK_BDEV_IO_STATUS_FAILED;
 	spdk_bdev_scsi_task_complete(&event);
 	CU_ASSERT_EQUAL(task.status, SPDK_SCSI_STATUS_CHECK_CONDITION);
-	CU_ASSERT_EQUAL(task.sense_data[2], SPDK_SCSI_SENSE_ABORTED_COMMAND);
+	CU_ASSERT_EQUAL(task.sense_data[2] & 0xf, SPDK_SCSI_SENSE_ABORTED_COMMAND);
 	CU_ASSERT_EQUAL(task.sense_data[12], SPDK_SCSI_ASC_NO_ADDITIONAL_SENSE);
 	CU_ASSERT_EQUAL(task.sense_data[13], SPDK_SCSI_ASCQ_CAUSE_NOT_REPORTABLE);
 }

--- a/test/nvmf/common.sh
+++ b/test/nvmf/common.sh
@@ -40,7 +40,7 @@ function detect_mellanox_nics()
 	# for nvmf target loopback test, suppose we only have one type of card.
 	for nvmf_nic_bdf in $nvmf_nic_bdfs
 	do
-		result=`find /sys -name $nvmf_nic_bdf | grep driver | awk -F / '{ print $6 }'`
+		result=`lspci -vvv -s $nvmf_nic_bdf | grep 'Kernel modules' | awk -F ' ' '{print $3}'`
 		if [ "$result" == "mlx5_core" ]; then
 			mlx_core_driver="mlx5_core"
 			mlx_ib_driver="mlx5_ib"

--- a/test/nvmf/discovery/discovery.sh
+++ b/test/nvmf/discovery/discovery.sh
@@ -32,8 +32,8 @@ trap "killprocess $nvmfpid; exit 1" SIGINT SIGTERM EXIT
 
 waitforlisten $nvmfpid ${RPC_PORT}
 
-$rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE
-$rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE
+bdevs="$bdevs $($rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE)"
+bdevs="$bdevs $($rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE)"
 
 modprobe -v nvme-rdma
 
@@ -42,7 +42,7 @@ if [ -e "/dev/nvme-fabrics" ]; then
 fi
 
 $rpc_py construct_nvmf_subsystem Direct nqn.2016-06.io.spdk:cnode1 'transport:RDMA traddr:192.168.100.8 trsvcid:4420' '' -p "*"
-$rpc_py construct_nvmf_subsystem Virtual nqn.2016-06.io.spdk:cnode2 'transport:RDMA traddr:192.168.100.8 trsvcid:4420' '' -s SPDK00000000000001 -n 'Malloc0 Malloc1'
+$rpc_py construct_nvmf_subsystem Virtual nqn.2016-06.io.spdk:cnode2 'transport:RDMA traddr:192.168.100.8 trsvcid:4420' '' -s SPDK00000000000001 -n "$bdevs"
 
 nvme discover -t rdma -a $NVMF_FIRST_TARGET_IP -s $NVMF_PORT
 

--- a/test/nvmf/filesystem/filesystem.sh
+++ b/test/nvmf/filesystem/filesystem.sh
@@ -27,8 +27,8 @@ trap "killprocess $nvmfpid; exit 1" SIGINT SIGTERM EXIT
 
 waitforlisten $nvmfpid ${RPC_PORT}
 
-$rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE
-$rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE
+bdevs="$bdevs $($rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE)"
+bdevs="$bdevs $($rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE)"
 
 modprobe -v nvme-rdma
 
@@ -37,7 +37,7 @@ if [ -e "/dev/nvme-fabrics" ]; then
 fi
 
 $rpc_py construct_nvmf_subsystem Direct nqn.2016-06.io.spdk:cnode1 'transport:RDMA traddr:192.168.100.8 trsvcid:4420' '' -p "*"
-$rpc_py construct_nvmf_subsystem Virtual nqn.2016-06.io.spdk:cnode2 'transport:RDMA traddr:192.168.100.8 trsvcid:4420' '' -s SPDK00000000000001 -n 'Malloc0 Malloc1'
+$rpc_py construct_nvmf_subsystem Virtual nqn.2016-06.io.spdk:cnode2 'transport:RDMA traddr:192.168.100.8 trsvcid:4420' '' -s SPDK00000000000001 -n "$bdevs"
 
 nvme connect -t rdma -n "nqn.2016-06.io.spdk:cnode1" -a "$NVMF_FIRST_TARGET_IP" -s "$NVMF_PORT"
 nvme connect -t rdma -n "nqn.2016-06.io.spdk:cnode2" -a "$NVMF_FIRST_TARGET_IP" -s "$NVMF_PORT"

--- a/test/nvmf/fio/fio.sh
+++ b/test/nvmf/fio/fio.sh
@@ -27,8 +27,8 @@ trap "killprocess $nvmfpid; exit 1" SIGINT SIGTERM EXIT
 
 waitforlisten $nvmfpid ${RPC_PORT}
 
-$rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE
-$rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE
+bdevs="$bdevs $($rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE)"
+bdevs="$bdevs $($rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE)"
 
 modprobe -v nvme-rdma
 
@@ -37,7 +37,7 @@ if [ -e "/dev/nvme-fabrics" ]; then
 fi
 
 $rpc_py construct_nvmf_subsystem Direct nqn.2016-06.io.spdk:cnode1 'transport:RDMA traddr:192.168.100.8 trsvcid:4420' '' -p "*"
-$rpc_py construct_nvmf_subsystem Virtual nqn.2016-06.io.spdk:cnode2 'transport:RDMA traddr:192.168.100.8 trsvcid:4420' '' -s SPDK00000000000001 -n 'Malloc0 Malloc1'
+$rpc_py construct_nvmf_subsystem Virtual nqn.2016-06.io.spdk:cnode2 'transport:RDMA traddr:192.168.100.8 trsvcid:4420' '' -s SPDK00000000000001 -n "$bdevs"
 
 nvme connect -t rdma -n "nqn.2016-06.io.spdk:cnode1" -a "$NVMF_FIRST_TARGET_IP" -s "$NVMF_PORT"
 nvme connect -t rdma -n "nqn.2016-06.io.spdk:cnode2" -a "$NVMF_FIRST_TARGET_IP" -s "$NVMF_PORT"

--- a/test/nvmf/nvme_cli/nvme_cli.sh
+++ b/test/nvmf/nvme_cli/nvme_cli.sh
@@ -26,8 +26,8 @@ trap "killprocess $nvmfpid; exit 1" SIGINT SIGTERM EXIT
 
 waitforlisten $nvmfpid ${RPC_PORT}
 
-$rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE
-$rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE
+bdevs="$bdevs $($rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE)"
+bdevs="$bdevs $($rpc_py construct_malloc_bdev $MALLOC_BDEV_SIZE $MALLOC_BLOCK_SIZE)"
 
 modprobe -v nvme-rdma
 
@@ -36,7 +36,7 @@ if [ -e "/dev/nvme-fabrics" ]; then
 fi
 
 $rpc_py construct_nvmf_subsystem Direct nqn.2016-06.io.spdk:cnode1 'transport:RDMA traddr:192.168.100.8 trsvcid:4420' '' -p "*"
-$rpc_py construct_nvmf_subsystem Virtual nqn.2016-06.io.spdk:cnode2 'transport:RDMA traddr:192.168.100.8 trsvcid:4420' '' -s SPDK00000000000001 -n 'Malloc0 Malloc1'
+$rpc_py construct_nvmf_subsystem Virtual nqn.2016-06.io.spdk:cnode2 'transport:RDMA traddr:192.168.100.8 trsvcid:4420' '' -s SPDK00000000000001 -n "$bdevs"
 
 nvme connect -t rdma -n "nqn.2016-06.io.spdk:cnode1" -a "$NVMF_FIRST_TARGET_IP" -s "$NVMF_PORT"
 nvme connect -t rdma -n "nqn.2016-06.io.spdk:cnode2" -a "$NVMF_FIRST_TARGET_IP" -s "$NVMF_PORT"


### PR DESCRIPTION
Custom bdev modules can return any SCSI sense information to a host by this patch. This is usefull when a custome bdev module detect an error in the module and need to return meaningful information to a host.