### PR TITLE
bdev: add members for SCSI error information in spdk_bdev_io

### DIFF
--- a/include/spdk/bdev.h
+++ b/include/spdk/bdev.h
@@ -137,6 +137,7 @@ struct spdk_bdev_fn_table {
 
 /** Blockdev I/O completion status */
 enum spdk_bdev_io_status {
+	SPDK_BDEV_IO_STATUS_SCSI_ERROR = -3,
 	SPDK_BDEV_IO_STATUS_NVME_ERROR = -2,
 	SPDK_BDEV_IO_STATUS_FAILED = -1,
 	SPDK_BDEV_IO_STATUS_PENDING = 0,
@@ -252,6 +253,17 @@ struct spdk_bdev_io {
 			/** NVMe status code */
 			int sc;
 		} nvme;
+		/** Only valid when status is SPDK_BDEV_IO_STATUS_SCSI_ERROR */
+		struct {
+			/** SCSI status code */
+			enum spdk_scsi_status sc;
+			/** SCSI sense key */
+			enum spdk_scsi_sense sk;
+			/** SCSI additional sense code */
+			uint8_t asc;
+			/** SCSI additional sense code qualifier */
+			uint8_t ascq;
+		} scsi;
 	} error;
 
 	/** User function that will be called when this completes */
@@ -321,4 +333,6 @@ int spdk_bdev_free_io(struct spdk_bdev_io *bdev_io);
 int spdk_bdev_reset(struct spdk_bdev *bdev, enum spdk_bdev_reset_type,
 		    spdk_bdev_io_completion_cb cb, void *cb_arg);
 struct spdk_io_channel *spdk_bdev_get_io_channel(struct spdk_bdev *bdev, uint32_t priority);
+void spdk_bdev_io_set_scsi_error(struct spdk_bdev_io *bdev_io, enum spdk_scsi_status sc,
+				 enum spdk_scsi_sense sk, uint8_t asc, uint8_t ascq);
 #endif /* SPDK_BDEV_H_ */

--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -837,6 +837,17 @@ spdk_bdev_io_complete(struct spdk_bdev_io *bdev_io, enum spdk_bdev_io_status sta
 }
 
 void
+spdk_bdev_io_set_scsi_error(struct spdk_bdev_io *bdev_io, enum spdk_scsi_status sc,
+			    enum spdk_scsi_sense sk, uint8_t asc, uint8_t ascq)
+{
+	bdev_io->status = SPDK_BDEV_IO_STATUS_SCSI_ERROR;
+	bdev_io->error.scsi.sc = sc;
+	bdev_io->error.scsi.sk = sk;
+	bdev_io->error.scsi.asc = asc;
+	bdev_io->error.scsi.ascq = ascq;
+}
+
+void
 spdk_bdev_register(struct spdk_bdev *bdev)
 {
 	/* initialize the reset generation value to zero */


### PR DESCRIPTION
Custom bdev modules can return any SCSI status and SCSI sense information to a host by this patch. This is usefull when a custome bdev module detect an error in the module and need to return meaningful
information to a host.
(The previous PR is #57)