### PR TITLE
scsi: fix panic issue of spdk_scsi_dev_queue_task

### DIFF
--- a/lib/scsi/dev.c
+++ b/lib/scsi/dev.c
@@ -198,9 +198,10 @@ spdk_scsi_dev_queue_task(struct spdk_scsi_dev *dev,
 {
 	assert(task != NULL);
 
-	/* ready to enqueue, disk is valid for LUN access */
-	spdk_scsi_lun_append_task(task->lun, task);
-	spdk_scsi_lun_execute_tasks(task->lun);
+	if (spdk_scsi_lun_append_task(task->lun, task) == 0) {
+		/* ready to execute, disk is valid for LUN access */
+		spdk_scsi_lun_execute_tasks(task->lun);
+	}
 }
 
 int

--- a/lib/scsi/lun.c
+++ b/lib/scsi/lun.c
@@ -214,15 +214,16 @@ complete_task_with_no_lun(struct spdk_scsi_task *task)
 	spdk_scsi_lun_complete_task(NULL, task);
 }
 
-void
+int
 spdk_scsi_lun_append_task(struct spdk_scsi_lun *lun, struct spdk_scsi_task *task)
 {
 	if (lun == NULL) {
 		complete_task_with_no_lun(task);
-		return;
+		return -1;
 	}
 
 	TAILQ_INSERT_TAIL(&lun->pending_tasks, task, scsi_link);
+	return 0;
 }
 
 void

--- a/lib/scsi/scsi_internal.h
+++ b/lib/scsi/scsi_internal.h
@@ -77,7 +77,7 @@ typedef struct spdk_scsi_lun _spdk_scsi_lun;
 _spdk_scsi_lun *spdk_scsi_lun_construct(const char *name, struct spdk_bdev *bdev);
 
 void spdk_scsi_lun_clear_all(struct spdk_scsi_lun *lun);
-void spdk_scsi_lun_append_task(struct spdk_scsi_lun *lun, struct spdk_scsi_task *task);
+int spdk_scsi_lun_append_task(struct spdk_scsi_lun *lun, struct spdk_scsi_task *task);
 void spdk_scsi_lun_execute_tasks(struct spdk_scsi_lun *lun);
 int spdk_scsi_lun_task_mgmt_execute(struct spdk_scsi_task *task);
 void spdk_scsi_lun_complete_task(struct spdk_scsi_lun *lun, struct spdk_scsi_task *task);

--- a/test/lib/scsi/dev/dev_ut.c
+++ b/test/lib/scsi/dev/dev_ut.c
@@ -107,9 +107,10 @@ spdk_scsi_lun_task_mgmt_execute(struct spdk_scsi_task *task)
 	return 0;
 }
 
-void
+int
 spdk_scsi_lun_append_task(struct spdk_scsi_lun *lun, struct spdk_scsi_task *task)
 {
+	return 0;
 }
 
 void


### PR DESCRIPTION
When task->lun is NULL, spdk_scsi_dev_queue_task makes panic by calling spdk_scsi_lun_execute_tasks. This patch fixes it.