### PR TITLE
nvme: fix ctrlr free issue

### DIFF
--- a/lib/nvme/nvme.c
+++ b/lib/nvme/nvme.c
@@ -324,7 +324,6 @@ spdk_nvme_probe(void *cb_ctx, spdk_nvme_probe_cb probe_cb, spdk_nvme_attach_cb a
 				/* Controller failed to initialize. */
 				TAILQ_REMOVE(&g_spdk_nvme_driver->init_ctrlrs, ctrlr, tailq);
 				nvme_ctrlr_destruct(ctrlr);
-				spdk_free(ctrlr);
 				rc = -1;
 				break;
 			}


### PR DESCRIPTION
spdk_nvme_probe frees ctrlr when nvme_ctrlr_process_init is failed. But ctrlr has already been freed while calling nvme_ctrlr_destruct. So, spdk_nvme_probe doen't need to free ctrlr.