### PR TITLE
nvme: return 1 when the device is not supported in nvme_probe_one

### DIFF
--- a/lib/bdev/nvme/blockdev_nvme.c
+++ b/lib/bdev/nvme/blockdev_nvme.c
@@ -390,6 +390,10 @@ probe_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
 		return false;
 	}
 
+	if (ctx->controllers_remaining > 0) {
+		ctx->controllers_remaining--;
+	}
+
 	/* Claim the device in case conflict with other process */
 	if (spdk_pci_device_claim(&probe_info->pci_addr) != 0) {
 		return false;
@@ -402,7 +406,6 @@ static void
 attach_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
 	  struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *opts)
 {
-	struct nvme_probe_ctx *ctx = cb_ctx;
 	struct nvme_device *dev;
 
 	dev = malloc(sizeof(struct nvme_device));
@@ -419,10 +422,6 @@ attach_cb(void *cb_ctx, const struct spdk_nvme_probe_info *probe_info,
 	spdk_io_device_register(ctrlr, blockdev_nvme_create_cb, blockdev_nvme_destroy_cb,
 				sizeof(struct nvme_io_channel));
 	TAILQ_INSERT_TAIL(&g_nvme_devices, dev, tailq);
-
-	if (ctx->controllers_remaining > 0) {
-		ctx->controllers_remaining--;
-	}
 }
 
 static bool

--- a/lib/nvme/nvme.c
+++ b/lib/nvme/nvme.c
@@ -248,6 +248,9 @@ nvme_probe_one(enum spdk_nvme_transport transport, spdk_nvme_probe_cb probe_cb, 
 		ctrlr->probe_info = *probe_info;
 
 		TAILQ_INSERT_TAIL(&g_spdk_nvme_driver->init_ctrlrs, ctrlr, tailq);
+	} else {
+		/* The device is not supported */
+		return 1;
 	}
 
 	return 0;


### PR DESCRIPTION
When we try to add some nvme bdevs using rpc.py script with construct_nvme_bdev option, the first device is added successfully. But the second or later devices are failed to add. This patch fixes the issue.