### PR TITLE
test/iscsi_tgt: delete verify.state file in fio.sh

### DIFF
--- a/test/iscsi_tgt/fio/fio.sh
+++ b/test/iscsi_tgt/fio/fio.sh
@@ -87,9 +87,7 @@ if [ $RUN_NIGHTLY -eq 1 ]; then
 	running_config
 fi
 
-if [ -f "./local-job0-0-verify.state" ]; then
-	mv ./local-job0-0-verify.state $output_dir
-fi
+rm -f ./local-job0-0-verify.state
 
 trap - SIGINT SIGTERM EXIT
 


### PR DESCRIPTION
When $output_dir is current directory, mv command fails and fio.sh script also fails.
I just delete the verify.state file the same as test/nvmf/fio/fio.sh does.