### PR TITLE
scsi: no check lun->dev in spdk_scsi_lun_deletable

### DIFF
--- a/lib/scsi/lun.c
+++ b/lib/scsi/lun.c
@@ -356,11 +356,6 @@ spdk_scsi_lun_deletable(const char *name)
 		goto out;
 	}
 
-	if (lun->dev == NULL) {
-		ret = 0;
-		goto out;
-	}
-
 out:
 	pthread_mutex_unlock(&g_spdk_scsi.mutex);
 	return ret;

--- a/test/lib/scsi/lun/lun_ut.c
+++ b/test/lib/scsi/lun/lun_ut.c
@@ -637,6 +637,21 @@ lun_construct_success(void)
 	CU_ASSERT_EQUAL(g_task_count, 0);
 }
 
+static void
+lun_deletable(void)
+{
+	struct spdk_scsi_lun *lun;
+	int rc;
+
+	lun = lun_construct();
+	rc = spdk_scsi_lun_deletable(lun->name);
+	CU_ASSERT_EQUAL(rc, 0);
+	lun_destruct(lun);
+
+	rc = spdk_scsi_lun_deletable("test");
+	CU_ASSERT_EQUAL(rc, -1);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -686,6 +701,7 @@ main(int argc, char **argv)
 		|| CU_add_test(suite, "destruct task - success", lun_destruct_success) == NULL
 		|| CU_add_test(suite, "construct - null ctx", lun_construct_null_ctx) == NULL
 		|| CU_add_test(suite, "construct - success", lun_construct_success) == NULL
+		|| CU_add_test(suite, "deletable", lun_deletable) == NULL
 	) {
 		CU_cleanup_registry();
 		return CU_get_error();


### PR DESCRIPTION
We don't need check lun->dev in spdk_scsi_lun_deletable.
Whichever dev is null or not null, spdk_scsi_lun_delete can delete a lun appropriately.