### PR TITLE
the enum fio_filetype member FIO_TYPE_DB has been changed to FIO_TYPE…

### DIFF
--- a/examples/nvme/fio_plugin/fio_plugin.c
+++ b/examples/nvme/fio_plugin/fio_plugin.c
@@ -166,7 +166,7 @@ attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid,
 				continue;
 			}
 
-			f->filetype = FIO_TYPE_BD;
+			f->filetype = FIO_TYPE_BLOCK;
 			fio_file_set_size_known(f);
 
 			fio_ns->next = fio_ctrlr->ns_list;


### PR DESCRIPTION
The new changes in fio_plugin.c requires building with recent versions of fio header files. The enum fio_filetype member FIO_TYPE_DB has been changed to FIO_TYPE_BLOCK.