### PR TITLE
nvmf_tgt: modify removal timing of nvmf_tgt_subsystem from the list

### DIFF
--- a/app/nvmf_tgt/nvmf_tgt.c
+++ b/app/nvmf_tgt/nvmf_tgt.c
@@ -69,7 +69,6 @@ subsystem_delete_event(void *arg1, void *arg2)
 	struct nvmf_tgt_subsystem *app_subsys = arg1;
 	struct spdk_nvmf_subsystem *subsystem = app_subsys->subsystem;
 
-	TAILQ_REMOVE(&g_subsystems, app_subsys, tailq);
 	free(app_subsys);
 
 	spdk_nvmf_delete_subsystem(subsystem);
@@ -112,6 +111,7 @@ shutdown_subsystems(void)
 
 	g_subsystems_shutdown = true;
 	TAILQ_FOREACH_SAFE(app_subsys, &g_subsystems, tailq, tmp) {
+		TAILQ_REMOVE(&g_subsystems, app_subsys, tailq);
 		nvmf_tgt_delete_subsystem(app_subsys);
 	}
 }
@@ -260,6 +260,7 @@ nvmf_tgt_delete_subsystems(void)
 	struct spdk_nvmf_subsystem *subsystem;
 
 	TAILQ_FOREACH_SAFE(app_subsys, &g_subsystems, tailq, tmp) {
+		TAILQ_REMOVE(&g_subsystems, app_subsys, tailq);
 		subsystem = app_subsys->subsystem;
 		spdk_nvmf_delete_subsystem(subsystem);
 		free(app_subsys);


### PR DESCRIPTION
- subsystem_delete_event()
Delete TAILQ_REMOVE because nvmf_tgt_shutdown_subsystem_by_nqn has already called TAILQ_REMOVE.
- shutdown_subsystems()
Add TAILQ_REMOVE according to the above change.
- nvmf_tgt_delete_subsystems()
Add TAILQ_REMOVE.