### PR TITLE
env: Abstract DPDK dependences with SPDK env APIs.

### DIFF
--- a/app/iscsi_tgt/iscsi_tgt.c
+++ b/app/iscsi_tgt/iscsi_tgt.c
@@ -35,9 +35,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <rte_config.h>
-#include <rte_lcore.h>
-
 #include "spdk/env.h"
 #include "spdk/event.h"
 #include "iscsi/iscsi.h"
@@ -186,7 +183,7 @@ main(int argc, char **argv)
 	opts.usr1_handler = spdk_sigusr1;
 	spdk_app_init(&opts);
 
-	printf("Total cores available: %d\n", rte_lcore_count());
+	printf("Total cores available: %d\n", spdk_lcore_count());
 	printf("Using net framework %s\n", spdk_net_framework_get_name());
 	/* Blocks until the application is exiting */
 	app_rc = spdk_app_start(spdk_startup, NULL, NULL);

--- a/app/nvmf_tgt/Makefile
+++ b/app/nvmf_tgt/Makefile
@@ -40,7 +40,7 @@ APP = nvmf_tgt
 
 CFLAGS += $(ENV_CFLAGS)
 
-C_SRCS := conf.c nvmf_tgt.c nvmf_rpc.c
+C_SRCS := conf.c nvmf_main.c nvmf_tgt.c nvmf_rpc.c
 
 SPDK_LIB_LIST = nvmf event log trace conf util bdev copy rpc jsonrpc json
 SPDK_LIB_LIST += app_rpc log_rpc bdev_rpc

--- a/app/nvmf_tgt/nvmf_main.c
+++ b/app/nvmf_tgt/nvmf_main.c
@@ -1,0 +1,180 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright (c) Intel Corporation.
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "spdk/env.h"
+#include "nvmf_tgt.h"
+#include "spdk/event.h"
+#include "spdk/log.h"
+
+#define SPDK_NVMF_BUILD_ETC "/usr/local/etc/nvmf"
+#define SPDK_NVMF_DEFAULT_CONFIG SPDK_NVMF_BUILD_ETC "/nvmf.conf"
+
+/*! \file
+
+This is the main file.
+
+*/
+
+/*!
+
+\brief This is the main function for the NVMf target application.
+
+\msc
+
+	c_runtime [label="C Runtime"], nvmf [label="NVMf target"];
+	c_runtime=>nvmf [label="main()"];
+	nvmf=>nvmf [label="spdk_app_init()"];
+	nvmf=>nvmf [label="spdk_event_allocate()"];
+	nvmf=>nvmf [label="spdk_app_start()"];
+	nvmf=>nvmf [label="spdk_app_fini()"];
+	c_runtime<<nvmf;
+
+\endmsc
+
+*/
+
+static void
+usage(void)
+{
+        struct spdk_app_opts opts;
+
+	spdk_app_opts_init(&opts);
+
+	printf("nvmf [options]\n");
+	printf("options:\n");
+	printf(" -c config  - config file (default %s)\n", SPDK_NVMF_DEFAULT_CONFIG);
+	printf(" -e mask    - tracepoint group mask for spdk trace buffers (default 0x0)\n");
+	printf(" -m mask    - core mask for DPDK\n");
+	printf(" -i shared memory ID (optional)\n");
+	printf(" -l facility - use specific syslog facility (default %s)\n",
+	       opts.log_facility);
+	printf(" -n channel number of memory channels used for DPDK\n");
+	printf(" -p core    master (primary) core for DPDK\n");
+	printf(" -s size    memory size in MB for DPDK\n");
+
+	spdk_tracelog_usage(stdout, "-t");
+
+	printf(" -v         - verbose (enable warnings)\n");
+	printf(" -H         - show this usage\n");
+	printf(" -d         - disable coredump file enabling\n");
+}
+
+
+int
+main(int argc, char **argv)
+{
+	int ch;
+	int rc;
+	struct spdk_app_opts opts = {};
+
+	/* default value in opts */
+	spdk_app_opts_init(&opts);
+	opts.name = "nvmf";
+	opts.config_file = SPDK_NVMF_DEFAULT_CONFIG;
+	opts.max_delay_us = 1000; /* 1 ms */
+
+	while ((ch = getopt(argc, argv, "c:de:i:l:m:n:p:qs:t:DH")) != -1) {
+		switch (ch) {
+		case 'd':
+			opts.enable_coredump = false;
+			break;
+		case 'c':
+			opts.config_file = optarg;
+			break;
+		case 'i':
+			opts.shm_id = atoi(optarg);
+			break;
+		case 'l':
+			opts.log_facility = optarg;
+			break;
+		case 't':
+			rc = spdk_log_set_trace_flag(optarg);
+			if (rc < 0) {
+				fprintf(stderr, "unknown flag\n");
+				usage();
+				exit(EXIT_FAILURE);
+			}
+#ifndef DEBUG
+			fprintf(stderr, "%s must be rebuilt with CONFIG_DEBUG=y for -t flag.\n",
+				argv[0]);
+			usage();
+			exit(EXIT_FAILURE);
+#endif
+			break;
+		case 'm':
+			opts.reactor_mask = optarg;
+			break;
+		case 'n':
+			opts.dpdk_mem_channel = atoi(optarg);
+			break;
+		case 'p':
+			opts.dpdk_master_core = atoi(optarg);
+			break;
+		case 's':
+			opts.dpdk_mem_size = atoi(optarg);
+			break;
+		case 'e':
+			opts.tpoint_group_mask = optarg;
+			break;
+		case 'q':
+			spdk_g_notice_stderr_flag = 0;
+			break;
+		case 'D':
+		case 'H':
+		default:
+			usage();
+			exit(EXIT_SUCCESS);
+		}
+	}
+
+	if (spdk_g_notice_stderr_flag == 1 &&
+	    isatty(STDERR_FILENO) &&
+	    !strncmp(ttyname(STDERR_FILENO), "/dev/tty", strlen("/dev/tty"))) {
+		printf("Warning: printing stderr to console terminal without -q option specified.\n");
+		printf("Suggest using -q to disable logging to stderr and monitor syslog, or\n");
+		printf("redirect stderr to a file.\n");
+		printf("(Delaying for 10 seconds...)\n");
+		sleep(10);
+	}
+
+	rc = spdk_nvmf_tgt_start(&opts);
+
+	return rc;
+}

--- a/app/nvmf_tgt/nvmf_tgt.c
+++ b/app/nvmf_tgt/nvmf_tgt.c
@@ -38,11 +38,9 @@
 #include <unistd.h>
 #include <signal.h>
 
-#include <rte_config.h>
-#include <rte_lcore.h>
-
 #include "nvmf_tgt.h"
 
+#include "spdk/env.h"
 #include "spdk/bdev.h"
 #include "spdk/event.h"
 #include "spdk/log.h"
@@ -223,7 +221,7 @@ nvmf_tgt_create_subsystem(const char *name, enum spdk_nvmf_subtype subtype,
 	app_subsys->lcore = lcore;
 
 	SPDK_NOTICELOG("allocated subsystem %s on lcore %u on socket %u\n", name, lcore,
-		       rte_lcore_to_socket_id(lcore));
+		       spdk_lcore_to_socket_id(lcore));
 
 	TAILQ_INSERT_TAIL(&g_subsystems, app_subsys, tailq);
 
@@ -324,7 +322,7 @@ spdk_nvmf_startup(void *arg1, void *arg2)
 			     g_spdk_nvmf_tgt_conf.acceptor_poll_rate);
 
 	SPDK_NOTICELOG("Acceptor running on core %u on socket %u\n", g_spdk_nvmf_tgt_conf.acceptor_lcore,
-		       rte_lcore_to_socket_id(g_spdk_nvmf_tgt_conf.acceptor_lcore));
+		       spdk_lcore_to_socket_id(g_spdk_nvmf_tgt_conf.acceptor_lcore));
 
 	if (getenv("MEMZONE_DUMP") != NULL) {
 		spdk_memzone_dump(stdout);
@@ -443,7 +441,7 @@ main(int argc, char **argv)
 	opts.shutdown_cb = spdk_nvmf_shutdown_cb;
 	spdk_app_init(&opts);
 
-	printf("Total cores available: %d\n", rte_lcore_count());
+	printf("Total cores available: %d\n", spdk_lcore_count());
 	/* Blocks until the application is exiting */
 	rc = spdk_app_start(spdk_nvmf_startup, NULL, NULL);
 

--- a/app/nvmf_tgt/nvmf_tgt.h
+++ b/app/nvmf_tgt/nvmf_tgt.h
@@ -38,6 +38,7 @@
 
 #include "spdk/nvmf.h"
 #include "spdk/queue.h"
+#include "spdk/event.h"
 
 struct rpc_listen_address {
 	char *transport;
@@ -85,4 +86,7 @@ spdk_nvmf_construct_subsystem(const char *name,
 
 int
 nvmf_tgt_shutdown_subsystem_by_nqn(const char *nqn);
+
+int
+spdk_nvmf_tgt_start(struct spdk_app_opts *opts);
 #endif

--- a/examples/nvme/identify/identify.c
+++ b/examples/nvme/identify/identify.c
@@ -38,9 +38,6 @@
 #include <unistd.h>
 #include <string.h>
 
-#include <rte_config.h>
-#include <rte_lcore.h>
-
 #include "spdk/log.h"
 #include "spdk/nvme.h"
 #include "spdk/env.h"

--- a/examples/nvme/nvme_manage/nvme_manage.c
+++ b/examples/nvme/nvme_manage/nvme_manage.c
@@ -42,9 +42,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-#include <rte_config.h>
-#include <rte_lcore.h>
-
 #include "spdk/nvme.h"
 #include "spdk/env.h"
 #include "spdk/util.h"

--- a/examples/nvme/reserve/reserve.c
+++ b/examples/nvme/reserve/reserve.c
@@ -37,9 +37,6 @@
 #include <unistd.h>
 #include <inttypes.h>
 
-#include <rte_config.h>
-#include <rte_lcore.h>
-
 #include "spdk/nvme.h"
 #include "spdk/env.h"
 

--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -31,6 +31,11 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
+ *   Copyright (c) 1992-2017 NetApp, Inc.
+ *   All rights reserved.
+ */
+
 /** \file
  * Encapsulated third-party dependencies
  */
@@ -62,6 +67,16 @@ struct spdk_env_opts {
 	int	 		dpdk_master_core;
 	int			dpdk_mem_size;
 };
+
+/**
+ * State of an lcore.
+ */
+enum spdk_lcore_state_t {
+	WAIT_0,       /**< waiting a new command */
+	RUNNING_1,    /**< executing command */
+	FINISHED_2,   /**< command executed */
+};
+
 
 /**
  * \brief Initialize the default value of opts
@@ -126,6 +141,8 @@ void spdk_memzone_dump(FILE *f);
 
 struct spdk_mempool;
 
+#define SPDK_MEMPOOL_CACHE_MAX_SIZE 512
+
 /**
  * Create a thread-safe memory pool. Cache size is the number of
  * elements in a thread-local cache. Can be 0 for no caching, or -1
@@ -147,6 +164,13 @@ void spdk_mempool_free(struct spdk_mempool *mp);
 void *spdk_mempool_get(struct spdk_mempool *mp);
 
 /**
+ * Get an element from a memory pool and return the element handle.
+ * If no elements remain, return -ENOENT.
+ */
+int spdk_mempool_get2(struct spdk_mempool *mp, void **elm);
+
+
+/**
  * Put an element back into the memory pool.
  */
 void spdk_mempool_put(struct spdk_mempool *mp, void *ele);
@@ -156,6 +180,12 @@ void spdk_mempool_put(struct spdk_mempool *mp, void *ele);
  */
 void spdk_mempool_put_bulk(struct spdk_mempool *mp, void *const *ele_arr, size_t count);
 
+/**
+ * Return the number of entries in the mempool.
+ */
+unsigned spdk_mempool_avail_count(const struct spdk_mempool *pool);
+
+char *spdk_mempool_name(const struct spdk_mempool *pool);
 
 /**
  * Return true if the calling process is primary process
@@ -288,6 +318,546 @@ int spdk_pci_addr_fmt(char *bdf, size_t sz, const struct spdk_pci_addr *addr);
  */
 void *spdk_call_unaffinitized(void *cb(void *arg), void *arg);
 
+struct spdk_ring;
+
+#define RING_F_SP_ENQ 0x0001 /**< The default enqueue is "single-producer". */
+#define RING_F_SC_DEQ 0x0002 /**< The default dequeue is "single-consumer". */
+
+/**
+ * Enqueue several objects on the ring (multi-producers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * producer index atomically.
+ *
+ * \param sr
+ *   A pointer to the spdk_ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects).
+ * \param n
+ *   The number of objects to add in the ring from the obj_table.
+ * \return
+ *   - 0: Success; objects enqueue.
+ *   - -EDQUOT: Quota exceeded. The objects have been enqueued, but the
+ *     high water mark is exceeded.
+ *   - -ENOBUFS: Not enough room in the ring to enqueue, no object is enqueued.
+ */
+int
+spdk_ring_mp_enqueue_bulk(struct spdk_ring *sr, void *const *obj_table,
+			  unsigned n);
+/**
+ * Enqueue several objects on a spdk ring (NOT multi-producers safe).
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects).
+ * \param n
+ *   The number of objects to add in the ring from the obj_table.
+ * \return
+ *   - 0: Success; objects enqueued.
+ *   - -EDQUOT: Quota exceeded. The objects have been enqueued, but the
+ *     high water mark is exceeded.
+ *   - -ENOBUFS: Not enough room in the ring to enqueue; no object is enqueued.
+ */
+int
+spdk_ring_sp_enqueue_bulk(struct spdk_ring *sr, void *const *obj_table,
+			  unsigned n);
+
+/**
+ * Enqueue several objects on a spdk ring.
+ *
+ * This function calls the multi-producer or the single-producer
+ * version depending on the default behavior that was specified at
+ * ring creation time (see flags).
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects).
+ * \param n
+ *   The number of objects to add in the ring from the obj_table.
+ * \return
+ *   - 0: Success; objects enqueued.
+ *   - -EDQUOT: Quota exceeded. The objects have been enqueued, but the
+ *     high water mark is exceeded.
+ *   - -ENOBUFS: Not enough room in the ring to enqueue; no object is enqueued.
+ */
+int
+spdk_ring_enqueue_bulk(struct spdk_ring *sr, void *const *obj_table,
+		       unsigned n);
+/**
+ * Enqueue one object on a spdk ring (multi-producers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * producer index atomically.
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj
+ *   A pointer to the object to be added.
+ * \return
+ *   - 0: Success; objects enqueued.
+ *   - -EDQUOT: Quota exceeded. The objects have been enqueued, but the
+ *     high water mark is exceeded.
+ *   - -ENOBUFS: Not enough room in the ring to enqueue; no object is enqueued.
+ */
+int
+spdk_ring_mp_enqueue(struct spdk_ring *sr, void *obj);
+
+/**
+ * Enqueue one object on a spdk ring (NOT multi-producers safe).
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj
+ *   A pointer to the object to be added.
+ * \return
+ *   - 0: Success; objects enqueued.
+ *   - -EDQUOT: Quota exceeded. The objects have been enqueued, but the
+ *     high water mark is exceeded.
+ *   - -ENOBUFS: Not enough room in the ring to enqueue; no object is enqueued.
+ */
+int
+spdk_ring_sp_enqueue(struct spdk_ring *sr, void *obj);
+
+/**
+ * Enqueue one object on a spdk ring.
+ *
+ * This function calls the multi-producer or the single-producer
+ * version, depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj
+ *   A pointer to the object to be added.
+ * \return
+ *   - 0: Success; objects enqueued.
+ *   - -EDQUOT: Quota exceeded. The objects have been enqueued, but the
+ *     high water mark is exceeded.
+ *   - -ENOBUFS: Not enough room in the ring to enqueue; no object is enqueued.
+ */
+int
+spdk_ring_enqueue(struct spdk_ring *sr, void *obj);
+
+/**
+ * Dequeue several objects from a spdk  ring (multi-consumers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * consumer index atomically.
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects) that will be filled.
+ * \param n
+ *   The number of objects to dequeue from the ring to the obj_table.
+ * \return
+ *   - 0: Success; objects dequeued.
+ *   - -ENOENT: Not enough entries in the ring to dequeue; no object is
+ *     dequeued.
+ */
+int
+spdk_ring_mc_dequeue_bulk(struct spdk_ring *sr, void **obj_table, unsigned n);
+
+/**
+ * Dequeue several objects from a spdk ring (NOT multi-consumers safe).
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects) that will be filled.
+ * \param n
+ *   The number of objects to dequeue from the ring to the obj_table,
+ *   must be strictly positive.
+ * \return
+ *   - 0: Success; objects dequeued.
+ *   - -ENOENT: Not enough entries in the ring to dequeue; no object is
+ *     dequeued.
+ */
+int
+spdk_ring_sc_dequeue_bulk(struct spdk_ring *sr, void **obj_table, unsigned n);
+
+/**
+ * Dequeue several objects from a spdk ring.
+ *
+ * This function calls the multi-consumers or the single-consumer
+ * version, depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ * \param sr
+ *   A pointer to the ring spdk structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects) that will be filled.
+ * \param n
+ *   The number of objects to dequeue from the ring to the obj_table.
+ * \return
+ *   - 0: Success; objects dequeued.
+ *   - -ENOENT: Not enough entries in the ring to dequeue, no object is
+ *     dequeued.
+ */
+int
+spdk_ring_dequeue_bulk(struct spdk_ring *sr, void **obj_table, unsigned n);
+
+/**
+ * Dequeue one object from a spdk ring (multi-consumers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * consumer index atomically.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_p
+ *   A pointer to a void * pointer (object) that will be filled.
+ * \return
+ *   - 0: Success; objects dequeued.
+ *   - -ENOENT: Not enough entries in the ring to dequeue; no object is
+ *     dequeued.
+ */
+int
+spdk_ring_mc_dequeue(struct spdk_ring *sr, void **obj_p);
+/**
+ * Dequeue one object from a spdk ring (NOT multi-consumers safe).
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_p
+ *   A pointer to a void * pointer (object) that will be filled.
+ * \return
+ *   - 0: Success; objects dequeued.
+ *   - -ENOENT: Not enough entries in the ring to dequeue, no object is
+ *     dequeued.
+ */
+int
+spdk_ring_sc_dequeue(struct spdk_ring *sr, void **obj_p);
+
+/**
+ * Dequeue one object from a spdk ring.
+ *
+ * This function calls the multi-consumers or the single-consumer
+ * version depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_p
+ *   A pointer to a void * pointer (object) that will be filled.
+ * \return
+ *   - 0: Success, objects dequeued.
+ *   - -ENOENT: Not enough entries in the ring to dequeue, no object is
+ *     dequeued.
+ */
+int
+spdk_ring_dequeue(struct spdk_ring *sr, void **obj_p);
+
+/**
+ * Test if a spdk ring is full.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \return
+ *   - 1: The ring is full.
+ *   - 0: The ring is not full.
+ */
+int
+spdk_ring_full(const struct spdk_ring *sr);
+
+/**
+ * Test if a spdk ring is empty.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \return
+ *   - 1: The ring is empty.
+ *   - 0: The ring is not empty.
+ */
+int
+spdk_ring_empty(const struct spdk_ring *sr);
+
+/**
+ * Return the number of entries in a spdk ring.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \return
+ *   The number of entries in the ring.
+ */
+unsigned
+spdk_ring_count(const struct spdk_ring *sr);
+
+/**
+ * Return the number of free entries in a spdk ring.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \return
+ *   The number of free entries in the ring.
+ */
+unsigned
+spdk_ring_free_count(const struct spdk_ring *sr);
+
+/**
+ * Enqueue several objects on the ring (multi-producers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * producer index atomically.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects).
+ * \param n
+ *   The number of objects to add in the ring from the obj_table.
+ * \return
+ *   - n: Actual number of objects enqueued.
+ */
+unsigned
+spdk_ring_mp_enqueue_burst(struct spdk_ring *sr, void *const *obj_table,
+			   unsigned n);
+
+/**
+ * Enqueue several objects on a spdk ring (NOT multi-producers safe).
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects).
+ * \param n
+ *   The number of objects to add in the ring from the obj_table.
+ * \return
+ *   - n: Actual number of objects enqueued.
+ */
+unsigned
+spdk_ring_sp_enqueue_burst(struct spdk_ring *sr, void *const *obj_table,
+			   unsigned n);
+/**
+ * Enqueue several objects on a spdk ring.
+ *
+ * This function calls the multi-producer or the single-producer
+ * version depending on the default behavior that was specified at
+ * ring creation time (see flags).
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects).
+ * \param n
+ *   The number of objects to add in the ring from the obj_table.
+ * \return
+ *   - n: Actual number of objects enqueued.
+ */
+unsigned
+spdk_ring_enqueue_burst(struct spdk_ring *sr, void *const *obj_table,
+			unsigned n);
+/**
+ * Dequeue several objects from a spdk ring (multi-consumers safe). When the request
+ * objects are more than the available objects, only dequeue the actual number
+ * of objects
+ *
+ * This function uses a "compare and set" instruction to move the
+ * consumer index atomically.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects) that will be filled.
+ * \param n
+ *   The number of objects to dequeue from the ring to the obj_table.
+ * \return
+ *   - n: Actual number of objects dequeued, 0 if ring is empty
+ */
+unsigned
+spdk_ring_mc_dequeue_burst(struct spdk_ring *sr, void **obj_table, unsigned n);
+
+/**
+ * Dequeue several objects from a spdk ring (NOT multi-consumers safe).When the
+ * request objects are more than the available objects, only dequeue the
+ * actual number of objects
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects) that will be filled.
+ * \param n
+ *   The number of objects to dequeue from the ring to the obj_table.
+ * \return
+ *   - n: Actual number of objects dequeued, 0 if ring is empty
+ */
+unsigned
+spdk_ring_sc_dequeue_burst(struct spdk_ring *sr, void **obj_table, unsigned n);
+
+/**
+ * Dequeue multiple objects from a spdk ring up to a maximum number.
+ *
+ * This function calls the multi-consumers or the single-consumer
+ * version, depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects) that will be filled.
+ * \param n
+ *   The number of objects to dequeue from the ring to the obj_table.
+ * \return
+ *   - Number of objects dequeued
+ */
+unsigned
+spdk_ring_dequeue_burst(struct spdk_ring *sr, void **obj_table, unsigned n);
+
+/**
+ * return the size of memory occupied by a ring
+ */
+ssize_t spdk_ring_get_memsize(unsigned count);
+
+/**
+ * Create a ring
+ */
+struct spdk_ring *
+spdk_ring_create(const char *name, unsigned count, int socket_id, unsigned flags);
+
+/**
+ * free the ring
+ */
+void spdk_ring_free(struct spdk_ring *sr);
+
+/**
+ * Change the high water mark. If *count* is 0, water marking is
+ * disabled
+ */
+int spdk_ring_set_water_mark(struct spdk_ring *sr, unsigned count);
+
+/**
+ * dump the status of the ring on the console
+ */
+void spdk_ring_dump(FILE *f, const struct spdk_ring *sr);
+
+/**
+ * dump the status of all rings on the console
+ */
+void spdk_ring_list_dump(FILE *f);
+
+/**
+ * search a ring from its name
+ */
+struct spdk_ring *spdk_ring_lookup(const char *name);
+
+#define SPDK_MAX_LCORE 128
+
+/**
+ * Return the ID of the execution unit we are running on.
+ * \return
+ *  Logical core ID (in EAL thread) or LCORE_ID_ANY (in non-EAL thread)
+ */
+unsigned
+spdk_lcore_id(void);
+
+/**
+ * Get the id of the master lcore
+ *
+ * \return
+ *   the id of the master lcore
+ */
+unsigned
+spdk_get_master_lcore(void);
+
+/**
+ * Get the ID of the physical socket of the specified lcore
+ *
+ * \param lcore_id
+ *   the targeted lcore, which MUST be between 0 and RTE_MAX_LCORE-1.
+ * \return
+ *   the ID of lcoreid's physical socket
+ */
+unsigned
+spdk_lcore_to_socket_id(unsigned lcore_id);
+
+
+/**
+ * Test if an lcore is enabled.
+ *
+ * \param lcore_id
+ *   The identifier of the lcore, which MUST be between 0 and
+ *   RTE_MAX_LCORE-1.
+ * \return
+ *   True if the given lcore is enabled; false otherwise.
+ */
+int
+spdk_lcore_is_enabled(unsigned lcore_id);
+
+/**
+ * Return the number of execution units (lcores) on the system.
+ *
+ * \return
+ *   the number of execution units (lcores) on the system.
+ */
+unsigned
+spdk_lcore_count(void);
+
+/**
+ * Get the next enabled lcore ID.
+ *
+ * \param i
+ *   The current lcore (reference).
+ * \param skip_master
+ *   If true, do not return the ID of the master lcore.
+ * \param wrap
+ *   If true, go back to 0 when SPDK_MAX_LCORE is reached; otherwise,
+ *   return SPDK_MAX_LCORE.
+ * \return
+ *   The next lcore_id or SPDK_MAX_LCORE if not found.
+ */
+unsigned
+spdk_get_next_lcore(unsigned i, int skip_master, int wrap);
+
+/**
+ * Macro to browse all running lcores.
+ */
+#define SPDK_LCORE_FOREACH(i)						\
+	for (i = spdk_get_next_lcore(-1, 0, 0);				\
+	     i<SPDK_MAX_LCORE;						\
+	     i = spdk_get_next_lcore(i, 0, 0))
+
+/**
+ * Macro to browse all running lcores except the master lcore.
+ */
+#define SPDK_LCORE_FOREACH_SLAVE(i)					\
+	for (i = spdk_get_next_lcore(-1, 1, 0);				\
+	     i<SPDK_MAX_LCORE;						\
+	     i = spdk_get_next_lcore(i, 1, 0))
+
+/**
+ * Wait until a lcore finished its job.
+ */
+int
+spdk_wait_lcore(unsigned slave_id);
+
+/**
+ * Wait until on all the lcores.
+ */
+void
+spdk_mp_wait_lcore(void);
+
+/**
+ * Get the current state of the lcore.
+ */
+int
+spdk_get_lcore_state(unsigned lcore_id);
+
+/**
+ * Send a message to a slave lcore identified by slave_id to call a
+ * function f with argument arg. Once the execution is done, the
+ * remote lcore switch in FINISHED state.
+ */
+int
+spdk_remote_launch(int (*f)(void *), void *arg, unsigned slave_id);
+
+/**
+ * Memcpy
+ */
+void
+spdk_memcpy(void *dst, const void *src, int len);
+
 /**
  * Page-granularity memory address translation table
  */
@@ -350,6 +920,82 @@ void spdk_mem_register(void *vaddr, size_t len);
  *  are completed or cancelled before calling this function.
  */
 void spdk_mem_unregister(void *vaddr, size_t len);
+
+/**
+ * Return the physical address of an element in the mempool.
+ *
+ * @param mp
+ *   A pointer to the mempool structure.
+ * @param elt
+ *   A pointer (virtual address) to the element of the pool.
+ * @return
+ *   The physical address of the elt element.
+ *   If the mempool was created with MEMPOOL_F_NO_PHYS_CONTIG, the
+ *   returned value is RTE_BAD_PHYS_ADDR.
+ */
+uint64_t spdk_mempool_virt2phy(struct spdk_mempool *mp, void *elt);
+
+/**
+ * Return the ID of the physical socket of the logical core we are running on.
+ * @return
+ *   the ID of current lcoreid's physical socket
+ */
+int spdk_socket_id(void);
+
+/**
+ * Panic the system
+ */
+#define spdk_panic(...) spdk_panic_(__func__, __VA_ARGS__, "")
+#define spdk_panic_(func, format, ...) spdk_panic_fmt(func, format "%.0s", __VA_ARGS__)
+void spdk_panic_fmt(const char *func, const char *format, ...);
+
+/**
+ * Create a new mempool named *name* in memory.
+ *
+ * This function uses ``memzone_reserve`` to allocate memory. The
+ * pool contains n elements of elt_size. Its size is set to n.
+ *
+ * @param name
+ *   The name of the mempool.
+ * @param n
+ *   The number of elements in the mempool. The optimum size (in terms of
+ *   memory usage) for a mempool is when n is a power of two minus one:
+ *   n = (2^q - 1).
+ * @param elt_size
+ *   The size of each element.
+ * @param cache_size
+ *   If cache_size is non-zero, the spdk_mempool library will try to
+ *   limit the accesses to the common lockless pool, by maintaining a
+ *   per-lcore object cache. This argument must be lower or equal to
+ *   SPDK_MEMPOOL_CACHE_MAX_SIZE and n / 1.5. It is advised to choose
+ *   cache_size to have "n modulo cache_size == 0": if this is
+ *   not the case, some elements will always stay in the pool and will
+ *   never be used. The access to the per-lcore table is of course
+ *   faster than the multi-producer/consumer pool. The cache can be
+ *   disabled if the cache_size argument is set to 0; it can be useful to
+ *   avoid losing objects in cache.
+ * @param obj_init
+ *   A function pointer that is called for each object at
+ *   initialization of the pool. The user can set some meta data in
+ *   objects if needed. This parameter can be NULL if not needed.
+ *   See: spdk_mempool_obj_init_t
+ * @param obj_init_arg
+ *   An opaque pointer to data that can be used as an argument for
+ *   each call to the object constructor function.
+ * @param socket_id
+ *   The *socket_id* argument is the socket identifier in the case of
+ *   NUMA. The value can be *SOCKET_ID_ANY* if there is no NUMA
+ *   constraint for the reserved zone.
+ * @return
+ *   The pointer to the new allocated mempool, on success. NULL on error
+ */
+
+#define SPDK_MEMPOOL_CACHE_MAX_SIZE 512
+
+typedef void (spdk_mempool_obj_init_t)(struct spdk_mempool *mp, void *arg, void *obj, unsigned i);
+
+struct spdk_mempool *spdk_mempool_create_init(const char *name, size_t count, size_t ele_size,
+		size_t cache_size, spdk_mempool_obj_init_t *obj_init, void *obj_init_arg, int socket_id);
 
 #ifdef __cplusplus
 }

--- a/include/spdk_internal/bdev.h
+++ b/include/spdk_internal/bdev.h
@@ -181,7 +181,7 @@ spdk_bdev_io_from_ctx(void *ctx)
 }
 
 #define SPDK_BDEV_MODULE_REGISTER(init_fn, fini_fn, config_fn, ctx_size_fn)			\
-	static struct spdk_bdev_module_if init_fn ## _if = {					\
+	struct spdk_bdev_module_if init_fn ## _if = {					        \
 	.module_init 	= init_fn,								\
 	.module_fini	= fini_fn,								\
 	.config_text	= config_fn,								\

--- a/include/spdk_internal/copy_engine.h
+++ b/include/spdk_internal/copy_engine.h
@@ -82,7 +82,7 @@ void spdk_copy_engine_register(struct spdk_copy_engine *copy_engine);
 void spdk_copy_module_list_add(struct spdk_copy_module_if *copy_module);
 
 #define SPDK_COPY_MODULE_REGISTER(init_fn, fini_fn, config_fn, ctx_size_fn)				\
-	static struct spdk_copy_module_if init_fn ## _if = {						\
+	struct spdk_copy_module_if init_fn ## _if = {						\
 	.module_init 	= init_fn,									\
 	.module_fini	= fini_fn,									\
 	.config_text	= config_fn,									\

--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -39,10 +39,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <rte_config.h>
-#include <rte_mempool.h>
-#include <rte_version.h>
-
+#include "spdk/env.h"
 #include "spdk/queue.h"
 #include "spdk/nvme_spec.h"
 
@@ -54,13 +51,13 @@
 #define RBUF_SMALL_POOL_SIZE	8192
 #define RBUF_LARGE_POOL_SIZE	1024
 
-static struct rte_mempool *spdk_bdev_g_io_pool = NULL;
-static struct rte_mempool *g_rbuf_small_pool = NULL;
-static struct rte_mempool *g_rbuf_large_pool = NULL;
+static struct spdk_mempool *spdk_bdev_g_io_pool = NULL;
+static struct spdk_mempool *g_rbuf_small_pool = NULL;
+static struct spdk_mempool *g_rbuf_large_pool = NULL;
 
 typedef TAILQ_HEAD(, spdk_bdev_io) need_rbuf_tailq_t;
-static need_rbuf_tailq_t g_need_rbuf_small[RTE_MAX_LCORE];
-static need_rbuf_tailq_t g_need_rbuf_large[RTE_MAX_LCORE];
+static need_rbuf_tailq_t g_need_rbuf_small[SPDK_MAX_LCORE];
+static need_rbuf_tailq_t g_need_rbuf_large[SPDK_MAX_LCORE];
 
 static TAILQ_HEAD(, spdk_bdev_module_if) spdk_bdev_module_list =
 	TAILQ_HEAD_INITIALIZER(spdk_bdev_module_list);
@@ -125,7 +122,7 @@ spdk_bdev_io_set_rbuf(struct spdk_bdev_io *bdev_io, void *buf)
 static void
 spdk_bdev_io_put_rbuf(struct spdk_bdev_io *bdev_io)
 {
-	struct rte_mempool *pool;
+	struct spdk_mempool *pool;
 	struct spdk_bdev_io *tmp;
 	void *buf;
 	need_rbuf_tailq_t *tailq;
@@ -138,14 +135,14 @@ spdk_bdev_io_put_rbuf(struct spdk_bdev_io *bdev_io)
 
 	if (length <= SPDK_BDEV_SMALL_RBUF_MAX_SIZE) {
 		pool = g_rbuf_small_pool;
-		tailq = &g_need_rbuf_small[rte_lcore_id()];
+		tailq = &g_need_rbuf_small[spdk_lcore_id()];
 	} else {
 		pool = g_rbuf_large_pool;
-		tailq = &g_need_rbuf_large[rte_lcore_id()];
+		tailq = &g_need_rbuf_large[spdk_lcore_id()];
 	}
 
 	if (TAILQ_EMPTY(tailq)) {
-		rte_mempool_put(pool, buf);
+		spdk_mempool_put(pool, buf);
 	} else {
 		tmp = TAILQ_FIRST(tailq);
 		TAILQ_REMOVE(tailq, tmp, rbuf_link);
@@ -163,26 +160,26 @@ static int spdk_initialize_rbuf_pool(void)
 	 *   to account for.
 	 */
 	cache_size = RBUF_SMALL_POOL_SIZE / (2 * spdk_app_get_core_count());
-	if (cache_size > RTE_MEMPOOL_CACHE_MAX_SIZE)
-		cache_size = RTE_MEMPOOL_CACHE_MAX_SIZE;
-	g_rbuf_small_pool = rte_mempool_create("rbuf_small_pool",
-					       RBUF_SMALL_POOL_SIZE,
-					       SPDK_BDEV_SMALL_RBUF_MAX_SIZE + 512,
-					       cache_size, 0, NULL, NULL, NULL, NULL,
-					       SOCKET_ID_ANY, 0);
+	if (cache_size > SPDK_MEMPOOL_CACHE_MAX_SIZE)
+		cache_size = SPDK_MEMPOOL_CACHE_MAX_SIZE;
+	g_rbuf_small_pool = spdk_mempool_create("rbuf_small_pool",
+						RBUF_SMALL_POOL_SIZE,
+						SPDK_BDEV_SMALL_RBUF_MAX_SIZE + 512,
+						cache_size,
+						SPDK_ENV_SOCKET_ID_ANY);
 	if (!g_rbuf_small_pool) {
 		SPDK_ERRLOG("create rbuf small pool failed\n");
 		return -1;
 	}
 
 	cache_size = RBUF_LARGE_POOL_SIZE / (2 * spdk_app_get_core_count());
-	if (cache_size > RTE_MEMPOOL_CACHE_MAX_SIZE)
-		cache_size = RTE_MEMPOOL_CACHE_MAX_SIZE;
-	g_rbuf_large_pool = rte_mempool_create("rbuf_large_pool",
-					       RBUF_LARGE_POOL_SIZE,
-					       SPDK_BDEV_LARGE_RBUF_MAX_SIZE + 512,
-					       cache_size, 0, NULL, NULL, NULL, NULL,
-					       SOCKET_ID_ANY, 0);
+	if (cache_size > SPDK_MEMPOOL_CACHE_MAX_SIZE)
+		cache_size = SPDK_MEMPOOL_CACHE_MAX_SIZE;
+	g_rbuf_large_pool = spdk_mempool_create("rbuf_large_pool",
+						RBUF_LARGE_POOL_SIZE,
+						SPDK_BDEV_LARGE_RBUF_MAX_SIZE + 512,
+						cache_size,
+						SPDK_ENV_SOCKET_ID_ANY);
 	if (!g_rbuf_large_pool) {
 		SPDK_ERRLOG("create rbuf large pool failed\n");
 		return -1;
@@ -276,44 +273,32 @@ spdk_bdev_initialize(void)
 		return -1;
 	}
 
-	spdk_bdev_g_io_pool = rte_mempool_create("blockdev_io",
+	spdk_bdev_g_io_pool = spdk_mempool_create("blockdev_io",
 			      SPDK_BDEV_IO_POOL_SIZE,
 			      sizeof(struct spdk_bdev_io) +
 			      spdk_bdev_module_get_max_ctx_size(),
-			      64, 0,
-			      NULL, NULL, NULL, NULL,
-			      SOCKET_ID_ANY, 0);
+			      64,
+			      SPDK_ENV_SOCKET_ID_ANY);
 
 	if (spdk_bdev_g_io_pool == NULL) {
 		SPDK_ERRLOG("could not allocate spdk_bdev_io pool");
 		return -1;
 	}
 
-	for (i = 0; i < RTE_MAX_LCORE; i++) {
+	for (i = 0; i < SPDK_MAX_LCORE; i++) {
 		TAILQ_INIT(&g_need_rbuf_small[i]);
 		TAILQ_INIT(&g_need_rbuf_large[i]);
 	}
 
-	return spdk_initialize_rbuf_pool();
+	return  spdk_initialize_rbuf_pool();
 }
-
-/*
- * Wrapper to provide rte_mempool_avail_count() on older DPDK versions.
- * Drop this if the minimum DPDK version is raised to at least 16.07.
- */
-#if RTE_VERSION < RTE_VERSION_NUM(16, 7, 0, 1)
-static unsigned rte_mempool_avail_count(const struct rte_mempool *pool)
-{
-	return rte_mempool_count(pool);
-}
-#endif
 
 static int
-spdk_bdev_check_pool(struct rte_mempool *pool, uint32_t count)
+spdk_bdev_check_pool(struct spdk_mempool *pool, uint32_t count)
 {
-	if (rte_mempool_avail_count(pool) != count) {
-		SPDK_ERRLOG("rte_mempool_avail_count(%s) == %d, should be %d\n",
-			    pool->name, rte_mempool_avail_count(pool), count);
+	if (spdk_mempool_avail_count(pool) != count) {
+		SPDK_ERRLOG("spdk_mempool_avail_count(%p) == %d, should be %d\n",
+			    pool, spdk_mempool_avail_count(pool), count);
 		return -1;
 	} else {
 		return 0;
@@ -336,10 +321,9 @@ spdk_bdev_finish(void)
 struct spdk_bdev_io *spdk_bdev_get_io(void)
 {
 	struct spdk_bdev_io *bdev_io;
-	int rc;
 
-	rc = rte_mempool_get(spdk_bdev_g_io_pool, (void **)&bdev_io);
-	if (rc < 0 || !bdev_io) {
+	bdev_io = spdk_mempool_get(spdk_bdev_g_io_pool);
+	if (!bdev_io) {
 		SPDK_ERRLOG("Unable to get spdk_bdev_io\n");
 		abort();
 	}
@@ -360,28 +344,28 @@ spdk_bdev_put_io(struct spdk_bdev_io *bdev_io)
 		spdk_bdev_io_put_rbuf(bdev_io);
 	}
 
-	rte_mempool_put(spdk_bdev_g_io_pool, bdev_io);
+	spdk_mempool_put(spdk_bdev_g_io_pool, (void *)bdev_io);
 }
 
 static void
 _spdk_bdev_io_get_rbuf(struct spdk_bdev_io *bdev_io)
 {
 	uint64_t len = bdev_io->u.read.len;
-	struct rte_mempool *pool;
+	struct spdk_mempool *pool;
 	need_rbuf_tailq_t *tailq;
-	int rc;
 	void *buf = NULL;
 
 	if (len <= SPDK_BDEV_SMALL_RBUF_MAX_SIZE) {
 		pool = g_rbuf_small_pool;
-		tailq = &g_need_rbuf_small[rte_lcore_id()];
+		tailq = &g_need_rbuf_small[spdk_lcore_id()];
 	} else {
 		pool = g_rbuf_large_pool;
-		tailq = &g_need_rbuf_large[rte_lcore_id()];
+		tailq = &g_need_rbuf_large[spdk_lcore_id()];
 	}
 
-	rc = rte_mempool_get(pool, (void **)&buf);
-	if (rc < 0 || !buf) {
+	buf = spdk_mempool_get(pool);
+
+	if (!buf) {
 		TAILQ_INSERT_TAIL(tailq, bdev_io, rbuf_link);
 	} else {
 		spdk_bdev_io_set_rbuf(bdev_io, buf);
@@ -394,16 +378,16 @@ spdk_bdev_cleanup_pending_rbuf_io(struct spdk_bdev *bdev)
 {
 	struct spdk_bdev_io *bdev_io, *tmp;
 
-	TAILQ_FOREACH_SAFE(bdev_io, &g_need_rbuf_small[rte_lcore_id()], rbuf_link, tmp) {
+	TAILQ_FOREACH_SAFE(bdev_io, &g_need_rbuf_small[spdk_lcore_id()], rbuf_link, tmp) {
 		if (bdev_io->bdev == bdev) {
-			TAILQ_REMOVE(&g_need_rbuf_small[rte_lcore_id()], bdev_io, rbuf_link);
+			TAILQ_REMOVE(&g_need_rbuf_small[spdk_lcore_id()], bdev_io, rbuf_link);
 			bdev_io->status = SPDK_BDEV_IO_STATUS_FAILED;
 		}
 	}
 
-	TAILQ_FOREACH_SAFE(bdev_io, &g_need_rbuf_large[rte_lcore_id()], rbuf_link, tmp) {
+	TAILQ_FOREACH_SAFE(bdev_io, &g_need_rbuf_large[spdk_lcore_id()], rbuf_link, tmp) {
 		if (bdev_io->bdev == bdev) {
-			TAILQ_REMOVE(&g_need_rbuf_large[rte_lcore_id()], bdev_io, rbuf_link);
+			TAILQ_REMOVE(&g_need_rbuf_large[spdk_lcore_id()], bdev_io, rbuf_link);
 			bdev_io->status = SPDK_BDEV_IO_STATUS_FAILED;
 		}
 	}
@@ -936,7 +920,7 @@ spdk_bdev_register(struct spdk_bdev *bdev)
 void
 spdk_bdev_unregister(struct spdk_bdev *bdev)
 {
-	int			rc;
+	int rc;
 
 	SPDK_TRACELOG(SPDK_TRACE_DEBUG, "Removing bdev %s from list\n", bdev->name);
 

--- a/lib/copy/copy_engine.c
+++ b/lib/copy/copy_engine.c
@@ -37,9 +37,7 @@
 #include <stdio.h>
 #include <errno.h>
 
-#include <rte_config.h>
-#include <rte_memcpy.h>
-
+#include "spdk/env.h"
 #include "spdk/log.h"
 #include "spdk/io_channel.h"
 
@@ -112,7 +110,8 @@ mem_copy_submit(void *cb_arg, struct spdk_io_channel *ch, void *dst, void *src, 
 {
 	struct spdk_copy_task *copy_req;
 
-	rte_memcpy(dst, src, (size_t)nbytes);
+	spdk_memcpy(dst, src, (size_t)nbytes);
+
 	copy_req = (struct spdk_copy_task *)((uintptr_t)cb_arg -
 					     offsetof(struct spdk_copy_task, offload_ctx));
 	cb(copy_req, 0);

--- a/lib/env_dpdk/env.c
+++ b/lib/env_dpdk/env.c
@@ -31,10 +31,17 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "spdk/env.h"
+/*
+ *   Copyright (c) 1992-2017 NetApp, Inc.
+ *   All rights reserved.
+ */
 
+
+#include "spdk/env.h"
+#include "spdk/event.h"
 #include <string.h>
 #include <unistd.h>
+#include <assert.h>
 
 #include <rte_config.h>
 #include <rte_cycles.h>
@@ -42,6 +49,21 @@
 #include <rte_mempool.h>
 #include <rte_memzone.h>
 #include <rte_version.h>
+#include <rte_lcore.h>
+#include <rte_eal.h>
+#include <rte_log.h>
+#include <rte_debug.h>
+
+/*
+ * Insure the definitions in spdk/env.h are equivelant to the DPDK definitions.
+ */
+
+static_assert(SPDK_MAX_LCORE == RTE_MAX_LCORE, "SPDK_MAX_LCORE != RTE_MAX_LCORE");
+static_assert((int)WAIT == (int)WAIT_0, "WAIT != WAIT_0");
+static_assert((int)RUNNING == (int)RUNNING_1, "RUNNING != RUNNING_1");
+static_assert((int)FINISHED == (int)FINISHED_2, "FINISHED != FINISHED_2");
+static_assert(SPDK_MEMPOOL_CACHE_MAX_SIZE == RTE_MEMPOOL_CACHE_MAX_SIZE,
+	      "SPDK_MEMPOOL_CACHE_MAX_SIZE != RTE_MEMPOOL_CACHE_MAX_SIZE");
 
 void *
 spdk_malloc(size_t size, size_t align, uint64_t *phys_addr)
@@ -156,6 +178,39 @@ spdk_mempool_create(const char *name, size_t count,
 	return (struct spdk_mempool *)mp;
 }
 
+struct spdk_mempool *
+spdk_mempool_create_init(const char *name, size_t count,
+			 size_t ele_size, size_t cache_size,
+			 spdk_mempool_obj_init_t *obj_init,
+			 void *obj_init_arg, int socket_id)
+{
+	struct rte_mempool *mp;
+	size_t tmp;
+
+	if (socket_id == SPDK_ENV_SOCKET_ID_ANY) {
+		socket_id = SOCKET_ID_ANY;
+	}
+
+	/* No more than half of all elements can be in cache */
+	tmp = (count / 2) / rte_lcore_count();
+	if (cache_size > tmp) {
+		cache_size = tmp;
+	}
+
+	if (cache_size > RTE_MEMPOOL_CACHE_MAX_SIZE) {
+		cache_size = RTE_MEMPOOL_CACHE_MAX_SIZE;
+	}
+
+	mp = rte_mempool_create(name, count, ele_size, cache_size,
+				0, NULL, NULL,
+				(rte_mempool_obj_cb_t *) obj_init,
+				obj_init_arg,
+				socket_id, 0);
+
+	return (struct spdk_mempool *)mp;
+}
+
+
 void
 spdk_mempool_free(struct spdk_mempool *mp)
 {
@@ -168,11 +223,16 @@ void *
 spdk_mempool_get(struct spdk_mempool *mp)
 {
 	void *ele = NULL;
-
 	rte_mempool_get((struct rte_mempool *)mp, &ele);
-
 	return ele;
 }
+
+int
+spdk_mempool_get2(struct spdk_mempool *mp, void **ele)
+{
+	return (rte_mempool_get((struct rte_mempool *)mp, ele));
+}
+
 
 void
 spdk_mempool_put(struct spdk_mempool *mp, void *ele)
@@ -184,6 +244,23 @@ void
 spdk_mempool_put_bulk(struct spdk_mempool *mp, void *const *ele_arr, size_t count)
 {
 	rte_mempool_put_bulk((struct rte_mempool *)mp, ele_arr, count);
+}
+
+unsigned
+spdk_mempool_avail_count(const struct spdk_mempool *pool)
+{
+#if RTE_VERSION < RTE_VERSION_NUM(16, 7, 0, 1)
+	return rte_mempool_count((struct rte_mempool *)pool);
+#else
+	return rte_mempool_avail_count((struct rte_mempool *)pool);
+#endif
+}
+
+char *
+spdk_mempool_name(const struct spdk_mempool *pool)
+{
+	struct rte_mempool *mp = (struct rte_mempool *)pool;
+	return mp->name;
 }
 
 bool
@@ -236,4 +313,490 @@ spdk_call_unaffinitized(void *cb(void *arg), void *arg)
 	rte_thread_set_affinity(&orig_cpuset);
 
 	return ret;
+}
+
+/**
+ * Return the ID of the execution unit we are running on.
+ */
+unsigned
+spdk_lcore_id(void)
+{
+	return rte_lcore_id();
+}
+
+/**
+ * Get the id of the master lcore
+ */
+unsigned
+spdk_get_master_lcore(void)
+{
+	return rte_get_master_lcore();
+}
+
+/**
+ * Get the ID of the physical socket of the specified lcore
+ */
+unsigned
+spdk_lcore_to_socket_id(unsigned lcore_id)
+{
+	return rte_lcore_to_socket_id(lcore_id);
+}
+
+/**
+ * Test if an lcore is enabled.
+ */
+int
+spdk_lcore_is_enabled(unsigned lcore_id)
+{
+	return rte_lcore_is_enabled(lcore_id);
+}
+
+/**
+ * Return the number of execution units (lcores) on the system.
+ */
+unsigned
+spdk_lcore_count(void)
+{
+	return rte_lcore_count();
+}
+
+/**
+ * Get the next enabled lcore ID.
+ */
+unsigned
+spdk_get_next_lcore(unsigned i, int skip_master, int wrap)
+{
+	return rte_get_next_lcore(i, skip_master, wrap);
+}
+
+
+/**
+ * Wait for all  lcores to finish processing their jobs.
+ */
+void
+spdk_mp_wait_lcore(void)
+{
+	rte_eal_mp_wait_lcore();
+}
+
+/**
+ * Return the state of the lcore identified by slave_id.
+ */
+int
+spdk_get_lcore_state(unsigned lcore_id)
+{
+	return (int) rte_eal_get_lcore_state(lcore_id);
+}
+
+
+/**
+ * Wait until a lcore finished its job.
+ */
+int
+spdk_wait_lcore(unsigned slave_id)
+{
+	return rte_eal_wait_lcore(slave_id);
+}
+
+/**
+ * Send a message to a slave lcore identified by slave_id to call a
+ * function f with argument arg. Once the execution is done, the
+ * remote lcore switch in FINISHED state.
+ */
+int
+spdk_remote_launch(int (*f)(void *), void *arg, unsigned slave_id)
+{
+	return rte_eal_remote_launch(f, arg, slave_id);
+}
+
+/**
+ * Memcpy
+ */
+void
+spdk_memcpy(void *dst, const void *src, int len)
+{
+	rte_memcpy(dst, src, len);
+}
+
+uint64_t
+spdk_mempool_virt2phy(struct spdk_mempool *mp, void *elt)
+{
+	return (rte_mempool_virt2phy((const struct rte_mempool *)mp, (const void *)elt));
+}
+
+int
+spdk_socket_id(void)
+{
+	return (rte_socket_id());
+}
+
+void
+spdk_panic_fmt(const char *func, const char *format, ...)
+{
+	va_list ap;
+
+	rte_log(RTE_LOG_CRIT, RTE_LOGTYPE_EAL, "PANIC in %s():\n", func);
+	va_start(ap, format);
+	rte_vlog(RTE_LOG_CRIT, RTE_LOGTYPE_EAL, format, ap);
+	va_end(ap);
+	rte_dump_stack();
+	rte_dump_registers();
+	abort();
+}
+
+extern struct rte_tailq_elem rte_ring_tailq;
+
+/**
+ * Enqueue several objects on the ring (multi-producers safe).
+ *
+ */
+int
+spdk_ring_mp_enqueue_bulk(struct spdk_ring *sr, void *const *obj_table,
+			  unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_mp_enqueue_bulk(r, obj_table, n);
+}
+
+/**
+ * Enqueue several objects on a spdk ring (NOT multi-producers safe).
+ *
+ */
+int
+spdk_ring_sp_enqueue_bulk(struct spdk_ring *sr, void *const *obj_table,
+			  unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_sp_enqueue_bulk(r, obj_table, n);
+}
+
+/**
+ * Enqueue several objects on a spdk ring.
+ *
+ * This function calls the multi-producer or the single-producer
+ * version depending on the default behavior that was specified at
+ * ring creation time (see flags).
+ *
+ */
+int
+spdk_ring_enqueue_bulk(struct spdk_ring *sr, void *const *obj_table,
+		       unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_enqueue_bulk(r, obj_table, n);
+}
+
+/**
+ * Enqueue one object on a spdk ring (multi-producers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * producer index atomically.
+ *
+ */
+int
+spdk_ring_mp_enqueue(struct spdk_ring *sr, void *obj)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_mp_enqueue(r, obj);
+}
+
+/**
+ * Enqueue one object on a spdk ring (NOT multi-producers safe).
+ *
+ */
+int
+spdk_ring_sp_enqueue(struct spdk_ring *sr, void *obj)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_sp_enqueue(r, obj);
+}
+
+/**
+ * Enqueue one object on a spdk ring.
+ *
+ * This function calls the multi-producer or the single-producer
+ * version, depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ */
+int
+spdk_ring_enqueue(struct spdk_ring *sr, void *obj)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_enqueue(r, obj);
+}
+
+/**
+ * Dequeue several objects from a spdk	ring (multi-consumers safe).
+ *
+ */
+int
+spdk_ring_mc_dequeue_bulk(struct spdk_ring *sr, void **obj_table, unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_mc_dequeue_bulk(r, obj_table, n);
+}
+
+/**
+ * Dequeue several objects from a spdk ring (NOT multi-consumers safe).
+ *
+ */
+int
+spdk_ring_sc_dequeue_bulk(struct spdk_ring *sr, void **obj_table, unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_sc_dequeue_bulk(r, obj_table, n);
+}
+
+/**
+ * Dequeue several objects from a spdk ring.
+ *
+ * This function calls the multi-consumers or the single-consumer
+ * version, depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ */
+int
+spdk_ring_dequeue_bulk(struct spdk_ring *sr, void **obj_table, unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_dequeue_bulk(r, obj_table, n);
+}
+
+/**
+ * Dequeue one object from a spdk ring (multi-consumers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * consumer index atomically.
+ *
+ */
+int
+spdk_ring_mc_dequeue(struct spdk_ring *sr, void **obj_p)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_mc_dequeue(r, obj_p);
+}
+
+/**
+ * Dequeue one object from a spdk ring (NOT multi-consumers safe).
+ *
+ */
+int
+spdk_ring_sc_dequeue(struct spdk_ring *sr, void **obj_p)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_sc_dequeue(r, obj_p);
+}
+
+/**
+ * Dequeue one object from a spdk ring.
+ *
+ * This function calls the multi-consumers or the single-consumer
+ * version depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ */
+int
+spdk_ring_dequeue(struct spdk_ring *sr, void **obj_p)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_dequeue(r, obj_p);
+}
+
+/**
+ * Test if a spdk ring is full.
+ *
+ */
+int
+spdk_ring_full(const struct spdk_ring *sr)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_full(r);
+}
+
+/**
+ * Test if a spdk ring is empty.
+ *
+ */
+int
+spdk_ring_empty(const struct spdk_ring *sr)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_empty(r);
+}
+
+/**
+ * Return the number of entries in a spdk ring.
+ *
+ */
+unsigned
+spdk_ring_count(const struct spdk_ring *sr)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_count(r);
+}
+
+/**
+ * Return the number of free entries in a spdk ring.
+ *
+ */
+unsigned
+spdk_ring_free_count(const struct spdk_ring *sr)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_free_count(r);
+}
+
+/**
+ * Enqueue several objects on the ring (multi-producers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * producer index atomically.
+ *
+ */
+unsigned
+spdk_ring_mp_enqueue_burst(struct spdk_ring *sr, void *const *obj_table,
+			   unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_mp_enqueue_burst(r, obj_table, n);
+}
+
+/**
+ * Enqueue several objects on a spdk ring (NOT multi-producers safe).
+ *
+ */
+unsigned
+spdk_ring_sp_enqueue_burst(struct spdk_ring *sr, void *const *obj_table,
+			   unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_sp_enqueue_burst(r, obj_table, n);
+}
+
+/**
+ * Enqueue several objects on a spdk ring.
+ *
+ * This function calls the multi-producer or the single-producer
+ * version depending on the default behavior that was specified at
+ * ring creation time (see flags).
+ *
+ */
+unsigned
+spdk_ring_enqueue_burst(struct spdk_ring *sr, void *const *obj_table,
+			unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_enqueue_burst(r, obj_table, n);
+}
+
+/**
+ * Dequeue several objects from a spdk ring (multi-consumers safe). When the request
+ * objects are more than the available objects, only dequeue the actual number
+ * of objects
+ *
+ * This function uses a "compare and set" instruction to move the
+ * consumer index atomically.
+ *
+ */
+unsigned
+spdk_ring_mc_dequeue_burst(struct spdk_ring *sr, void **obj_table, unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_mc_dequeue_burst(r, obj_table, n);
+}
+
+/**
+ * Dequeue several objects from a spdk ring (NOT multi-consumers safe).When the
+ * request objects are more than the available objects, only dequeue the
+ * actual number of objects
+ */
+unsigned
+spdk_ring_sc_dequeue_burst(struct spdk_ring *sr, void **obj_table, unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_sc_dequeue_burst(r, obj_table, n);
+}
+
+/**
+ * Dequeue multiple objects from a spdk ring up to a maximum number.
+ *
+ * This function calls the multi-consumers or the single-consumer
+ * version, depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ */
+unsigned
+spdk_ring_dequeue_burst(struct spdk_ring *sr, void **obj_table, unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_dequeue_burst(r, obj_table, n);
+}
+
+
+/**
+ * Return the size of memory occupied by a ring
+ */
+ssize_t
+spdk_ring_get_memsize(unsigned count)
+{
+	return rte_ring_get_memsize(count);
+}
+
+/**
+ * Create a ring
+ */
+struct spdk_ring *
+spdk_ring_create(const char *name, unsigned count, int socket_id,
+		 unsigned flags)
+{
+	return (struct spdk_ring *) rte_ring_create(name, count, socket_id, flags);
+}
+
+/**
+ * Free the ring
+ */
+void
+spdk_ring_free(struct spdk_ring *sr)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	rte_ring_free(r);
+}
+
+/**
+ * Change the high water mark. If *count* is 0, water marking is
+ * disabled
+ */
+int
+spdk_ring_set_water_mark(struct spdk_ring *sr, unsigned count)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_set_water_mark(r, count);
+}
+
+/**
+ *  Dump the status of the ring on the console
+ */
+void
+spdk_ring_dump(FILE *f, const struct spdk_ring *sr)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	rte_ring_dump(f, r);
+}
+
+/**
+ * Dump the status of all rings on the console
+ */
+void
+spdk_ring_list_dump(FILE *f)
+{
+	rte_ring_list_dump(f);
+}
+
+/**
+ * Search a ring from its name
+ */
+struct spdk_ring *
+spdk_ring_lookup(const char *name)
+{
+	return (struct spdk_ring *)rte_ring_lookup(name);
 }

--- a/lib/iscsi/conn.c
+++ b/lib/iscsi/conn.c
@@ -44,9 +44,6 @@
 #include <sys/ioctl.h>
 #include <sys/epoll.h>
 
-#include <rte_config.h>
-#include <rte_mempool.h>
-
 #include "spdk/endian.h"
 #include "spdk/env.h"
 #include "spdk/event.h"
@@ -71,7 +68,7 @@ static int64_t g_conn_idle_interval_in_tsc = -1;
 #define DEFAULT_CONNECTIONS_PER_LCORE	4
 #define SPDK_MAX_POLLERS_PER_CORE	4096
 static int g_connections_per_lcore = DEFAULT_CONNECTIONS_PER_LCORE;
-static uint32_t g_num_connections[RTE_MAX_LCORE];
+static uint32_t g_num_connections[SPDK_MAX_LCORE];
 
 struct spdk_iscsi_conn *g_conns_array;
 static char g_shm_name[64];
@@ -273,7 +270,7 @@ int spdk_initialize_iscsi_conns(void)
 		g_conns_array[i].id = i;
 	}
 
-	for (i = 0; i < RTE_MAX_LCORE; i++) {
+	for (i = 0; i < SPDK_MAX_LCORE; i++) {
 		g_num_connections[i] = 0;
 	}
 
@@ -286,7 +283,7 @@ int spdk_initialize_iscsi_conns(void)
 	}
 
 	spdk_poller_register(&g_idle_conn_poller, spdk_iscsi_conn_idle_do_work, NULL,
-			     rte_get_master_lcore(), 0);
+			     spdk_get_master_lcore(), 0);
 
 	return 0;
 }
@@ -745,7 +742,7 @@ void spdk_shutdown_iscsi_conns(void)
 
 	pthread_mutex_unlock(&g_conns_mutex);
 	spdk_poller_register(&g_shutdown_timer, spdk_iscsi_conn_check_shutdown, NULL,
-			     rte_get_master_lcore(), 1000);
+			     spdk_get_master_lcore(), 1000);
 }
 
 int
@@ -1232,7 +1229,7 @@ static void spdk_iscsi_conn_handle_idle(struct spdk_iscsi_conn *conn)
 	    conn->pending_task_cnt == 0) {
 
 		spdk_trace_record(TRACE_ISCSI_CONN_IDLE, conn->id, 0, 0, 0);
-		spdk_iscsi_conn_stop_poller(conn, __add_idle_conn, rte_get_master_lcore());
+		spdk_iscsi_conn_stop_poller(conn, __add_idle_conn, spdk_get_master_lcore());
 	}
 }
 
@@ -1446,8 +1443,8 @@ static uint32_t
 spdk_iscsi_conn_allocate_reactor(uint64_t cpumask)
 {
 	uint32_t i, selected_core;
-	enum rte_lcore_state_t state;
-	uint32_t master_lcore = rte_get_master_lcore();
+	enum spdk_lcore_state_t state;
+	uint32_t master_lcore = spdk_get_master_lcore();
 	int32_t num_pollers, min_pollers;
 
 	cpumask &= spdk_app_get_core_mask();
@@ -1459,7 +1456,7 @@ spdk_iscsi_conn_allocate_reactor(uint64_t cpumask)
 	selected_core = 0;
 
 	/* we use u64 as CPU core mask */
-	for (i = 0; i < RTE_MAX_LCORE && i < 64; i++) {
+	for (i = 0; i < SPDK_MAX_LCORE && i < 64; i++) {
 		if (!((1ULL << i) & cpumask)) {
 			continue;
 		}
@@ -1469,24 +1466,24 @@ spdk_iscsi_conn_allocate_reactor(uint64_t cpumask)
 		 * So we always treat the reactor on master core as RUNNING.
 		 */
 		if (i == master_lcore) {
-			state = RUNNING;
+			state = RUNNING_1;
 		} else {
-			state = rte_eal_get_lcore_state(i);
+			state = spdk_get_lcore_state(i);
 		}
-		if (state == FINISHED) {
-			rte_eal_wait_lcore(i);
+		if (state == FINISHED_2) {
+			spdk_wait_lcore(i);
 		}
 
 		switch (state) {
-		case WAIT:
-		case FINISHED:
+		case WAIT_0:
+		case FINISHED_2:
 			/* Idle cores have 0 pollers. */
 			if (0 < min_pollers) {
 				selected_core = i;
 				min_pollers = 0;
 			}
 			break;
-		case RUNNING:
+		case RUNNING_1:
 			/* This lcore is running. Check how many pollers it already has. */
 			num_pollers = g_num_connections[i];
 

--- a/lib/iscsi/iscsi.c
+++ b/lib/iscsi/iscsi.c
@@ -32,6 +32,7 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <ctype.h>
 #include <stdint.h>
 #include <inttypes.h>
 
@@ -49,9 +50,6 @@
 #include <sys/uio.h>
 #include <fcntl.h>
 #include <time.h>
-
-#include <rte_config.h>
-#include <rte_mempool.h>
 
 #include "spdk/endian.h"
 #include "spdk/env.h"
@@ -313,7 +311,7 @@ int
 spdk_iscsi_read_pdu(struct spdk_iscsi_conn *conn, struct spdk_iscsi_pdu **_pdu)
 {
 	struct spdk_iscsi_pdu *pdu;
-	struct rte_mempool *pool;
+	struct spdk_mempool *pool;
 	uint32_t crc32c;
 	int ahs_len;
 	int data_len;
@@ -401,7 +399,7 @@ spdk_iscsi_read_pdu(struct spdk_iscsi_conn *conn, struct spdk_iscsi_pdu **_pdu)
 				conn->pdu_in_progress = NULL;
 				return SPDK_ISCSI_CONNECTION_FATAL;
 			}
-			rte_mempool_get(pool, (void **)&pdu->mobj);
+			spdk_mempool_get2(pool, (void **)&pdu->mobj);
 			if (pdu->mobj == NULL) {
 				*_pdu = NULL;
 				return SPDK_SUCCESS;
@@ -4432,7 +4430,7 @@ void spdk_free_sess(struct spdk_iscsi_sess *sess)
 	sess->session_type = SESSION_TYPE_INVALID;
 	spdk_iscsi_param_free(sess->params);
 	free(sess->conns);
-	rte_mempool_put(g_spdk_iscsi.session_pool, (void *)sess);
+	spdk_mempool_put(g_spdk_iscsi.session_pool, (void *)sess);
 }
 
 static int
@@ -4443,7 +4441,7 @@ spdk_create_iscsi_sess(struct spdk_iscsi_conn *conn,
 	struct spdk_iscsi_sess *sess;
 	int rc;
 
-	rc = rte_mempool_get(g_spdk_iscsi.session_pool, (void **)&sess);
+	rc = spdk_mempool_get2(g_spdk_iscsi.session_pool, (void **)&sess);
 	if ((rc < 0) || !sess) {
 		SPDK_ERRLOG("Unable to get session object\n");
 		SPDK_ERRLOG("MaxSessions set to %d\n", g_spdk_iscsi.MaxSessions);

--- a/lib/iscsi/iscsi.h
+++ b/lib/iscsi/iscsi.h
@@ -149,7 +149,7 @@
 #define ISCSI_AHS_LEN 60
 
 struct spdk_mobj {
-	struct rte_mempool *mp;
+	struct spdk_mempool *mp;
 	void *buf;
 	size_t len;
 	uint64_t reserved; /* do not use */
@@ -294,11 +294,11 @@ struct spdk_iscsi_globals {
 	uint32_t ErrorRecoveryLevel;
 	uint32_t AllowDuplicateIsid;
 
-	struct rte_mempool *pdu_pool;
-	struct rte_mempool *pdu_immediate_data_pool;
-	struct rte_mempool *pdu_data_out_pool;
-	struct rte_mempool *session_pool;
-	struct rte_mempool *task_pool;
+	struct spdk_mempool *pdu_pool;
+	struct spdk_mempool *pdu_immediate_data_pool;
+	struct spdk_mempool *pdu_data_out_pool;
+	struct spdk_mempool *session_pool;
+	struct spdk_mempool *task_pool;
 
 	struct spdk_iscsi_sess	**session;
 };

--- a/lib/iscsi/task.c
+++ b/lib/iscsi/task.c
@@ -32,9 +32,8 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <rte_config.h>
-#include <rte_mempool.h>
-
+#include <stdlib.h>
+#include "spdk/env.h"
 #include "spdk/log.h"
 #include "iscsi/task.h"
 
@@ -42,7 +41,7 @@ static void
 spdk_iscsi_task_free(struct spdk_scsi_task *task)
 {
 	spdk_iscsi_task_disassociate_pdu((struct spdk_iscsi_task *)task);
-	rte_mempool_put(g_spdk_iscsi.task_pool, (void *)task);
+	spdk_mempool_put(g_spdk_iscsi.task_pool, (void *)task);
 }
 
 struct spdk_iscsi_task *
@@ -51,7 +50,7 @@ spdk_iscsi_task_get(uint32_t *owner_task_ctr, struct spdk_iscsi_task *parent)
 	struct spdk_iscsi_task *task;
 	int rc;
 
-	rc = rte_mempool_get(g_spdk_iscsi.task_pool, (void **)&task);
+	rc = spdk_mempool_get2(g_spdk_iscsi.task_pool, (void **)&task);
 	if ((rc < 0) || !task) {
 		SPDK_ERRLOG("Unable to get task\n");
 		abort();

--- a/lib/json/json_write.c
+++ b/lib/json/json_write.c
@@ -147,7 +147,7 @@ emit_buf_full(struct spdk_json_write_ctx *w, const void *data, size_t size)
 	}
 
 	/* Recurse to emit the rest of the data. */
-	return emit(w, data + buf_remain, size - buf_remain);
+	return emit(w, (void *)((int *)data + buf_remain), size - buf_remain);
 }
 
 static int

--- a/lib/nvmf/rdma.c
+++ b/lib/nvmf/rdma.c
@@ -52,8 +52,6 @@
 #include "spdk/nvmf_spec.h"
 #include "spdk/string.h"
 #include "spdk/trace.h"
-#include "spdk/util.h"
-
 #include "spdk_internal/log.h"
 
 /*

--- a/lib/trace/trace.c
+++ b/lib/trace/trace.c
@@ -30,7 +30,6 @@
  *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include "spdk/env.h"
 #include "spdk/trace.h"
 
@@ -45,9 +44,6 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <errno.h>
-
-#include <rte_config.h>
-#include <rte_lcore.h>
 
 static char g_shm_name[64];
 
@@ -73,7 +69,7 @@ spdk_trace_record(uint16_t tpoint_id, uint16_t poller_id, uint32_t size,
 		return;
 	}
 
-	lcore = rte_lcore_id();
+	lcore = spdk_lcore_id();
 	if (lcore >= SPDK_TRACE_MAX_LCORE) {
 		return;
 	}

--- a/lib/vhost/rte_vhost/virtio_net.c
+++ b/lib/vhost/rte_vhost/virtio_net.c
@@ -35,6 +35,8 @@
 #include <stdbool.h>
 #include <linux/virtio_net.h>
 
+#include "spdk/env.h"
+
 #include <rte_mbuf.h>
 #include <rte_memcpy.h>
 #include <rte_ether.h>
@@ -95,7 +97,7 @@ static inline void __attribute__((always_inline))
 do_flush_shadow_used_ring(struct virtio_net *dev, struct vhost_virtqueue *vq,
 			  uint16_t to, uint16_t from, uint16_t size)
 {
-	rte_memcpy(&vq->used->ring[to],
+	spdk_memcpy(&vq->used->ring[to],
 			&vq->shadow_used_ring[from],
 			size * sizeof(struct vring_used_elem));
 	vhost_log_used_vring(dev, vq,
@@ -246,7 +248,7 @@ copy_mbuf_to_desc(struct virtio_net *dev, struct vring_desc *descs,
 		}
 
 		cpy_len = RTE_MIN(desc_avail, mbuf_avail);
-		rte_memcpy((void *)((uintptr_t)(desc_addr + desc_offset)),
+		spdk_memcpy((void *)((uintptr_t)(desc_addr + desc_offset)),
 			rte_pktmbuf_mtod_offset(m, void *, mbuf_offset),
 			cpy_len);
 		vhost_log_write(dev, desc->addr + desc_offset, cpy_len);
@@ -522,7 +524,7 @@ copy_mbuf_to_desc_mergeable(struct virtio_net *dev, struct rte_mbuf *m,
 		}
 
 		cpy_len = RTE_MIN(desc_avail, mbuf_avail);
-		rte_memcpy((void *)((uintptr_t)(desc_addr + desc_offset)),
+		spdk_memcpy((void *)((uintptr_t)(desc_addr + desc_offset)),
 			rte_pktmbuf_mtod_offset(m, void *, mbuf_offset),
 			cpy_len);
 		vhost_log_write(dev, buf_vec[vec_idx].buf_addr + desc_offset,
@@ -860,7 +862,7 @@ copy_desc_to_mbuf(struct virtio_net *dev, struct vring_desc *descs,
 			 */
 			mbuf_avail = cpy_len;
 		} else {
-			rte_memcpy(rte_pktmbuf_mtod_offset(cur, void *,
+			spdk_memcpy(rte_pktmbuf_mtod_offset(cur, void *,
 							   mbuf_offset),
 				(void *)((uintptr_t)(desc_addr + desc_offset)),
 				cpy_len);

--- a/lib/vhost/task.c
+++ b/lib/vhost/task.c
@@ -33,9 +33,6 @@
 
 #include <assert.h>
 
-#include <rte_config.h>
-#include <rte_mempool.h>
-
 #include "spdk_internal/log.h"
 #include "spdk_internal/event.h"
 #include "spdk/env.h"
@@ -49,10 +46,10 @@
 
 typedef TAILQ_HEAD(, spdk_vhost_task) need_iovecs_tailq_t;
 
-static struct rte_mempool *g_task_pool;
-static struct rte_mempool *g_iov_buffer_pool;
+static struct spdk_mempool *g_task_pool;
+static struct spdk_mempool *g_iov_buffer_pool;
 
-static need_iovecs_tailq_t g_need_iovecs[RTE_MAX_LCORE];
+static need_iovecs_tailq_t g_need_iovecs[SPDK_MAX_LCORE];
 
 void
 spdk_vhost_task_put(struct spdk_vhost_task *task)
@@ -67,7 +64,7 @@ spdk_vhost_task_free_cb(struct spdk_scsi_task *scsi_task)
 {
 	struct spdk_vhost_task *task = container_of(scsi_task, struct spdk_vhost_task, scsi);
 
-	rte_mempool_put(g_task_pool, task);
+	spdk_mempool_put(g_task_pool, task);
 }
 
 struct spdk_vhost_task *
@@ -76,10 +73,10 @@ spdk_vhost_task_get(uint32_t *owner_task_ctr)
 	struct spdk_vhost_task *task;
 	int rc;
 
-	rc = rte_mempool_get(g_task_pool, (void **)&task);
+	rc = spdk_mempool_get2(g_task_pool, (void **)&task);
 	if ((rc < 0) || !task) {
 		SPDK_ERRLOG("Unable to get task\n");
-		rte_panic("no memory\n");
+		spdk_panic("no memory\n");
 	}
 
 	memset(task, 0, sizeof(*task));
@@ -92,7 +89,7 @@ spdk_vhost_task_get(uint32_t *owner_task_ctr)
 void
 spdk_vhost_enqueue_task(struct spdk_vhost_task *task)
 {
-	need_iovecs_tailq_t *tailq = &g_need_iovecs[rte_lcore_id()];
+	need_iovecs_tailq_t *tailq = &g_need_iovecs[spdk_lcore_id()];
 
 	TAILQ_INSERT_TAIL(tailq, task, iovecs_link);
 }
@@ -100,7 +97,7 @@ spdk_vhost_enqueue_task(struct spdk_vhost_task *task)
 struct spdk_vhost_task *
 spdk_vhost_dequeue_task(void)
 {
-	need_iovecs_tailq_t *tailq = &g_need_iovecs[rte_lcore_id()];
+	need_iovecs_tailq_t *tailq = &g_need_iovecs[spdk_lcore_id()];
 	struct spdk_vhost_task *task;
 
 	if (TAILQ_EMPTY(tailq))
@@ -117,35 +114,35 @@ spdk_vhost_iovec_alloc(void)
 {
 	struct iovec *iov = NULL;
 
-	rte_mempool_get(g_iov_buffer_pool, (void **)&iov);
+	spdk_mempool_get2(g_iov_buffer_pool, (void **)&iov);
 	return iov;
 }
 
 void
 spdk_vhost_iovec_free(struct iovec *iov)
 {
-	rte_mempool_put(g_iov_buffer_pool, iov);
+	spdk_mempool_put(g_iov_buffer_pool, iov);
 }
 
 static int
 spdk_vhost_subsystem_init(void)
 {
-	g_task_pool = rte_mempool_create("vhost task pool", 16384, sizeof(struct spdk_vhost_task),
-					 128, 0, NULL, NULL, NULL, NULL, SOCKET_ID_ANY, 0);
+	g_task_pool = spdk_mempool_create("vhost task pool", 16384, sizeof(struct spdk_vhost_task),
+					  128, SPDK_ENV_SOCKET_ID_ANY);
 	if (!g_task_pool) {
 		SPDK_ERRLOG("create task pool failed\n");
 		return -1;
 	}
 
-	g_iov_buffer_pool = rte_mempool_create("vhost iov buffer pool", 2048,
-					       VHOST_SCSI_IOVS_LEN * sizeof(struct iovec),
-					       128, 0, NULL, NULL, NULL, NULL, SOCKET_ID_ANY, 0);
+	g_iov_buffer_pool = spdk_mempool_create("vhost iov buffer pool", 2048,
+						VHOST_SCSI_IOVS_LEN * sizeof(struct iovec),
+						128, SPDK_ENV_SOCKET_ID_ANY);
 	if (!g_iov_buffer_pool) {
 		SPDK_ERRLOG("create iov buffer pool failed\n");
 		return -1;
 	}
 
-	for (int i = 0; i < RTE_MAX_LCORE; i++) {
+	for (int i = 0; i < SPDK_MAX_LCORE; i++) {
 		TAILQ_INIT(&g_need_iovecs[i]);
 	}
 

--- a/lib/vhost/vhost.c
+++ b/lib/vhost/vhost.c
@@ -57,7 +57,7 @@
 #include "spdk/vhost.h"
 #include "task.h"
 
-static uint32_t g_num_ctrlrs[RTE_MAX_LCORE];
+static uint32_t g_num_ctrlrs[SPDK_MAX_LCORE];
 
 #define CONTROLQ_POLL_PERIOD_US (1000 * 5)
 
@@ -255,7 +255,7 @@ task_submit(struct spdk_vhost_task *task)
 	 */
 
 	task->resp->response = VIRTIO_SCSI_S_OK;
-	task->scsi.cb_event = spdk_event_allocate(rte_lcore_id(),
+	task->scsi.cb_event = spdk_event_allocate(spdk_lcore_id(),
 			      process_task_completion,
 			      task, NULL);
 	spdk_scsi_dev_queue_task(task->scsi_dev, &task->scsi);
@@ -265,7 +265,7 @@ static void
 mgmt_task_submit(struct spdk_vhost_task *task)
 {
 	task->tmf_resp->response = VIRTIO_SCSI_S_OK;
-	task->scsi.cb_event = spdk_event_allocate(rte_lcore_id(),
+	task->scsi.cb_event = spdk_event_allocate(spdk_lcore_id(),
 			      process_mgmt_task_completion,
 			      task, NULL);
 	spdk_scsi_dev_queue_mgmt_task(task->scsi_dev, &task->scsi);
@@ -621,7 +621,7 @@ static struct spdk_event *
 vhost_sem_event_alloc(uint32_t core, spdk_event_fn fn, void *arg1, sem_t *sem)
 {
 	if (sem_init(sem, 0, 0) < 0)
-		rte_panic("Failed to initialize semaphore.");
+		spdk_panic("Failed to initialize semaphore.");
 
 	return spdk_event_allocate(core, fn, arg1, sem);
 }
@@ -1047,7 +1047,7 @@ spdk_vhost_scsi_allocate_reactor(uint64_t cpumask)
 	min_ctrlrs = INT_MAX;
 	selected_core = 0;
 
-	for (i = 0; i < RTE_MAX_LCORE && i < 64; i++) {
+	for (i = 0; i < SPDK_MAX_LCORE && i < 64; i++) {
 		if (!((1ULL << i) & cpumask)) {
 			continue;
 		}

--- a/mk/spdk.common.mk
+++ b/mk/spdk.common.mk
@@ -48,6 +48,7 @@ OS := $(shell uname)
 COMMON_CFLAGS = -g $(C_OPT) -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wmissing-declarations -fno-strict-aliasing -march=native -m64 -I$(SPDK_ROOT_DIR)/include
 
 COMMON_CFLAGS += -include $(SPDK_ROOT_DIR)/config.h
+COMMON_CFLAGS += -I$(SPDK_ROOT_DIR)/lib/env_dpdk
 
 ifeq ($(CONFIG_WERROR), y)
 COMMON_CFLAGS += -Werror

--- a/test/lib/bdev/bdevperf/bdevperf.c
+++ b/test/lib/bdev/bdevperf/bdevperf.c
@@ -38,9 +38,7 @@
 #include <stdbool.h>
 #include <unistd.h>
 
-#include <rte_config.h>
-#include <rte_mempool.h>
-#include <rte_lcore.h>
+#include <rte_log.h>
 
 #include "spdk/bdev.h"
 #include "spdk/copy_engine.h"
@@ -91,7 +89,7 @@ struct io_target {
 	struct spdk_poller	*reset_timer;
 };
 
-struct io_target *head[RTE_MAX_LCORE];
+struct io_target *head[SPDK_MAX_LCORE];
 static int g_target_count = 0;
 
 /*
@@ -107,7 +105,7 @@ blockdev_heads_init(void)
 {
 	int i;
 
-	for (i = 0; i < RTE_MAX_LCORE; i++) {
+	for (i = 0; i < SPDK_MAX_LCORE; i++) {
 		head[i] = NULL;
 	}
 }
@@ -183,7 +181,7 @@ end_run(void *arg1, void *arg2)
 	}
 }
 
-struct rte_mempool *task_pool;
+struct spdk_mempool *task_pool;
 
 static void
 bdevperf_complete(struct spdk_bdev_io *bdev_io, enum spdk_bdev_io_status status, void *cb_arg)
@@ -212,7 +210,7 @@ bdevperf_complete(struct spdk_bdev_io *bdev_io, enum spdk_bdev_io_status status,
 	target->io_completed++;
 
 	bdev_io->caller_ctx = NULL;
-	rte_mempool_put(task_pool, task);
+	spdk_mempool_put(task_pool, task);
 
 	spdk_bdev_free_io(bdev_io);
 
@@ -225,7 +223,7 @@ bdevperf_complete(struct spdk_bdev_io *bdev_io, enum spdk_bdev_io_status status,
 	if (!target->is_draining) {
 		bdevperf_submit_single(target);
 	} else if (target->current_queue_depth == 0) {
-		complete = spdk_event_allocate(rte_get_master_lcore(), end_run, target, NULL);
+		complete = spdk_event_allocate(spdk_get_master_lcore(), end_run, target, NULL);
 		spdk_event_call(complete);
 	}
 }
@@ -277,7 +275,7 @@ bdevperf_verify_write_complete(struct spdk_bdev_io *bdev_io, enum spdk_bdev_io_s
 }
 
 static void
-task_ctor(struct rte_mempool *mp, void *arg, void *__task, unsigned id)
+task_ctor(struct spdk_mempool *mp, void *arg, void *__task, unsigned id)
 {
 	struct bdevperf_task *task = __task;
 
@@ -298,7 +296,7 @@ bdevperf_submit_single(struct io_target *target)
 	bdev = target->bdev;
 	ch = target->ch;
 
-	if (rte_mempool_get(task_pool, (void **)&task) != 0 || task == NULL) {
+	if (spdk_mempool_get2(task_pool, (void **)&task) != 0 || task == NULL) {
 		printf("Task pool allocation failed\n");
 		abort();
 	}
@@ -371,7 +369,7 @@ reset_cb(struct spdk_bdev_io *bdev_io, enum spdk_bdev_io_status status, void *cb
 		g_run_failed = true;
 	}
 
-	rte_mempool_put(task_pool, task);
+	spdk_mempool_put(task_pool, task);
 
 	spdk_poller_register(&target->reset_timer, reset_target, target, target->lcore,
 			     10 * 1000000);
@@ -386,7 +384,7 @@ reset_target(void *arg)
 	spdk_poller_unregister(&target->reset_timer, NULL);
 
 	/* Do reset. */
-	rte_mempool_get(task_pool, (void **)&task);
+	spdk_mempool_get2(task_pool, (void **)&task);
 	task->target = target;
 	spdk_bdev_reset(target->bdev, SPDK_BDEV_RESET_SOFT,
 			reset_cb, task);
@@ -490,7 +488,7 @@ bdevperf_run(void *arg1, void *arg2)
 	}
 
 	/* Send events to start all I/O */
-	RTE_LCORE_FOREACH(i) {
+	SPDK_LCORE_FOREACH(i) {
 		if (spdk_app_get_core_mask() & (1ULL << i)) {
 			target = head[i];
 			if (target != NULL) {
@@ -672,10 +670,10 @@ main(int argc, char **argv)
 
 	bdevperf_construct_targets();
 
-	task_pool = rte_mempool_create("task_pool", 4096 * spdk_app_get_core_count(),
-				       sizeof(struct bdevperf_task),
-				       64, 0, NULL, NULL, task_ctor, NULL,
-				       SOCKET_ID_ANY, 0);
+	task_pool = spdk_mempool_create_init("task_pool", 4096 * spdk_app_get_core_count(),
+					     sizeof(struct bdevperf_task),
+					     64, task_ctor, NULL,
+					     SPDK_ENV_SOCKET_ID_ANY);
 
 	spdk_app_start(bdevperf_run, NULL, NULL);
 

--- a/test/lib/event/event_perf/event_perf.c
+++ b/test/lib/event/event_perf/event_perf.c
@@ -37,10 +37,6 @@
 #include <stdbool.h>
 #include <unistd.h>
 
-#include <rte_config.h>
-#include <rte_ring.h>
-#include <rte_lcore.h>
-
 #include "spdk/env.h"
 #include "spdk/event.h"
 #include "spdk_internal/event.h"
@@ -52,16 +48,16 @@ static uint64_t g_tsc_us_rate;
 static int g_time_in_sec;
 
 static __thread uint64_t __call_count = 0;
-static uint64_t call_count[RTE_MAX_LCORE];
+static uint64_t call_count[SPDK_MAX_LCORE];
 
 static void
 submit_new_event(void *arg1, void *arg2)
 {
 	struct spdk_event *event;
-	static __thread uint32_t next_lcore = RTE_MAX_LCORE;
+	static __thread uint32_t next_lcore = SPDK_MAX_LCORE;
 
-	if (next_lcore == RTE_MAX_LCORE) {
-		next_lcore = rte_get_next_lcore(rte_lcore_id(), 0, 1);
+	if (next_lcore == SPDK_MAX_LCORE) {
+		next_lcore = spdk_get_next_lcore(spdk_lcore_id(), 0, 1);
 	}
 
 	++__call_count;
@@ -83,14 +79,14 @@ event_work_fn(void *arg)
 
 	while (1) {
 
-		spdk_event_queue_run_batch(rte_lcore_id());
+		spdk_event_queue_run_batch(spdk_lcore_id());
 
 		if (spdk_get_ticks() > tsc_end) {
 			break;
 		}
 	}
 
-	call_count[rte_lcore_id()] = __call_count;
+	call_count[spdk_lcore_id()] = __call_count;
 
 	return 0;
 }
@@ -110,7 +106,7 @@ performance_dump(int io_time)
 	uint32_t i;
 
 	printf("\n");
-	RTE_LCORE_FOREACH(i) {
+	SPDK_LCORE_FOREACH(i) {
 		printf("lcore %2d: %8ju\n", i, call_count[i] / g_time_in_sec);
 	}
 
@@ -159,14 +155,14 @@ main(int argc, char **argv)
 	fflush(stdout);
 
 	/* call event_work_fn on each slave lcore */
-	RTE_LCORE_FOREACH_SLAVE(i) {
-		rte_eal_remote_launch(event_work_fn, NULL, i);
+	SPDK_LCORE_FOREACH_SLAVE(i) {
+		spdk_remote_launch(event_work_fn, NULL, i);
 	}
 
 	/* call event_work_fn on lcore0 */
 	event_work_fn(NULL);
 
-	rte_eal_mp_wait_lcore();
+	spdk_mp_wait_lcore();
 
 	performance_dump(g_time_in_sec);
 

--- a/test/lib/nvme/aer/aer.c
+++ b/test/lib/nvme/aer/aer.c
@@ -38,9 +38,6 @@
 #include <unistd.h>
 #include <string.h>
 
-#include <rte_config.h>
-#include <rte_lcore.h>
-
 #include "spdk/log.h"
 #include "spdk/nvme.h"
 #include "spdk/env.h"

--- a/test/lib/nvme/e2edp/nvme_dp.c
+++ b/test/lib/nvme/e2edp/nvme_dp.c
@@ -41,9 +41,6 @@
 #include <inttypes.h>
 #include <string.h>
 
-#include <rte_config.h>
-#include <rte_lcore.h>
-
 #include "spdk/nvme.h"
 #include "spdk/env.h"
 

--- a/test/lib/nvme/overhead/overhead.c
+++ b/test/lib/nvme/overhead/overhead.c
@@ -39,9 +39,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <rte_config.h>
-#include <rte_lcore.h>
-
 #include "spdk/barrier.h"
 #include "spdk/fd.h"
 #include "spdk/nvme.h"
@@ -434,7 +431,7 @@ work_fn(void)
 {
 	uint64_t tsc_end;
 
-	printf("Starting work_fn on core %u\n", rte_lcore_id());
+	printf("Starting work_fn on core %u\n", spdk_lcore_id());
 
 	/* Allocate a queue pair for each namespace. */
 	if (init_ns_worker_ctx() != 0) {

--- a/test/lib/nvme/reset/reset.c
+++ b/test/lib/nvme/reset/reset.c
@@ -35,10 +35,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <rte_config.h>
-#include <rte_mempool.h>
-#include <rte_lcore.h>
+#include <stdlib.h>
 
 #include "spdk/nvme.h"
 #include "spdk/env.h"
@@ -82,7 +79,7 @@ struct worker_thread {
 	unsigned		lcore;
 };
 
-static struct rte_mempool *task_pool;
+static struct spdk_mempool *task_pool;
 
 static struct ctrlr_entry *g_controllers = NULL;
 static struct ns_entry *g_namespaces = NULL;
@@ -155,7 +152,7 @@ register_ctrlr(struct spdk_nvme_ctrlr *ctrlr)
 	}
 }
 
-static void task_ctor(struct rte_mempool *mp, void *arg, void *__task, unsigned id)
+static void task_ctor(struct spdk_mempool *mp, void *arg, void *__task, unsigned id)
 {
 	struct reset_task *task = __task;
 
@@ -178,8 +175,8 @@ submit_single_io(struct ns_worker_ctx *ns_ctx)
 	int			rc;
 	struct ns_entry		*entry = ns_ctx->entry;
 
-	if (rte_mempool_get(task_pool, (void **)&task) != 0) {
-		fprintf(stderr, "task_pool rte_mempool_get failed\n");
+	if (spdk_mempool_get2(task_pool, (void **)&task) != 0) {
+		fprintf(stderr, "task_pool spdk_mempool_get failed\n");
 		exit(1);
 	}
 
@@ -227,7 +224,7 @@ task_complete(struct reset_task *task, const struct spdk_nvme_cpl *completion)
 		ns_ctx->io_completed++;
 	}
 
-	rte_mempool_put(task_pool, task);
+	spdk_mempool_put(task_pool, task);
 
 	/*
 	 * is_draining indicates when time has expired for the test run
@@ -504,7 +501,7 @@ register_workers(void)
 	}
 
 	memset(worker, 0, sizeof(struct worker_thread));
-	worker->lcore = rte_get_master_lcore();
+	worker->lcore = spdk_get_master_lcore();
 
 	g_workers = worker;
 
@@ -633,10 +630,10 @@ int main(int argc, char **argv)
 		return rc;
 	}
 
-	task_pool = rte_mempool_create("task_pool", 8192,
-				       sizeof(struct reset_task),
-				       64, 0, NULL, NULL, task_ctor, NULL,
-				       SOCKET_ID_ANY, 0);
+	task_pool = spdk_mempool_create_init("task_pool", 8192,
+					     sizeof(struct reset_task),
+					     64, task_ctor, NULL,
+					     SPDK_ENV_SOCKET_ID_ANY);
 
 	g_tsc_rate = spdk_get_ticks_hz();
 


### PR DESCRIPTION
    - Implemented a wrapper funtions for rte_config.h, rte_mempool.h, rte_lcore.h APIs.
    - Updated lib/env_dpdk with new spdk APIs to call rte functions
    - Changes to nvmf_tgt and iscsi_tgt app code; example and test code to call
      spdk env wrapper functions instead of rte_ functions directly.
    - Added various and sundry new definitions and macros for abstraction