### PR TITLE
Abstract DPDK dependences with SPDK env APIs - Take 2

### DIFF
--- a/app/nvmf_tgt/conf.c
+++ b/app/nvmf_tgt/conf.c
@@ -40,11 +40,8 @@
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 
-#include <rte_config.h>
-#include <rte_lcore.h>
-
+#include "spdk/env.h"
 #include "nvmf_tgt.h"
-
 #include "spdk/conf.h"
 #include "spdk/log.h"
 #include "spdk/bdev.h"
@@ -144,7 +141,7 @@ spdk_add_nvmf_discovery_subsystem(void)
 
 	app_subsys = nvmf_tgt_create_subsystem(SPDK_NVMF_DISCOVERY_NQN, SPDK_NVMF_SUBTYPE_DISCOVERY,
 					       NVMF_SUBSYSTEM_MODE_DIRECT,
-					       rte_get_master_lcore());
+					       spdk_get_master_lcore());
 	if (app_subsys == NULL) {
 		SPDK_ERRLOG("Failed creating discovery nvmf library subsystem\n");
 		return -1;
@@ -209,7 +206,7 @@ spdk_nvmf_parse_nvmf_tgt(void)
 
 	acceptor_lcore = spdk_conf_section_get_intval(sp, "AcceptorCore");
 	if (acceptor_lcore < 0) {
-		acceptor_lcore = rte_lcore_id();
+		acceptor_lcore = spdk_lcore_id();
 	}
 	g_spdk_nvmf_tgt_conf.acceptor_lcore = acceptor_lcore;
 

--- a/app/nvmf_tgt/nvmf_tgt.c
+++ b/app/nvmf_tgt/nvmf_tgt.c
@@ -38,11 +38,9 @@
 #include <unistd.h>
 #include <signal.h>
 
-#include <rte_config.h>
-#include <rte_lcore.h>
-
 #include "nvmf_tgt.h"
 
+#include "spdk/env.h"
 #include "spdk/bdev.h"
 #include "spdk/event.h"
 #include "spdk/log.h"
@@ -317,7 +315,7 @@ spdk_nvmf_tgt_start(struct spdk_app_opts *opts)
 	opts->shutdown_cb = spdk_nvmf_shutdown_cb;
 	spdk_app_init(opts);
 
-	printf("Total cores available: %d\n", rte_lcore_count());
+	printf("Total cores available: %d\n", spdk_lcore_count());
 	/* Blocks until the application is exiting */
 	rc = spdk_app_start(spdk_nvmf_startup, NULL, NULL);
 

--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -870,6 +870,12 @@ int
 spdk_remote_launch(int (*f)(void *), void *arg, unsigned slave_id);
 
 /**
+ * Memcpy
+ */
+void
+spdk_memcpy(void *dst, const void *src, int len);
+
+/**
  * Page-granularity memory address translation table
  */
 struct spdk_mem_map;

--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -131,6 +131,8 @@ void spdk_memzone_dump(FILE *f);
 
 struct spdk_mempool;
 
+#define SPDK_MEMPOOL_CACHE_MAX_SIZE 512
+
 /**
  * Create a thread-safe memory pool. Cache size is the number of
  * elements in a thread-local cache. Can be 0 for no caching, or -1
@@ -160,6 +162,11 @@ void spdk_mempool_put(struct spdk_mempool *mp, void *ele);
  * Put multiple elements back into the memory pool.
  */
 void spdk_mempool_put_bulk(struct spdk_mempool *mp, void *const *ele_arr, size_t count);
+
+/**
+ * Return the number of entries in the mempool.
+ */
+unsigned spdk_mempool_avail_count(const struct spdk_mempool *pool);
 
 /**
  * \brief Return the number of dedicated CPU cores utilized by

--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -752,6 +752,116 @@ void spdk_ring_list_dump(FILE *f);
  */
 struct spdk_ring *spdk_ring_lookup(const char *name);
 
+#define SPDK_MAX_LCORE 128
+
+/**
+ * Return the ID of the execution unit we are running on.
+ * \return
+ *  Logical core ID (in EAL thread) or LCORE_ID_ANY (in non-EAL thread)
+ */
+unsigned
+spdk_lcore_id(void);
+
+/**
+ * Get the id of the master lcore
+ *
+ * \return
+ *   the id of the master lcore
+ */
+unsigned
+spdk_get_master_lcore(void);
+
+/**
+ * Get the ID of the physical socket of the specified lcore
+ *
+ * \param lcore_id
+ *   the targeted lcore, which MUST be between 0 and RTE_MAX_LCORE-1.
+ * \return
+ *   the ID of lcoreid's physical socket
+ */
+unsigned
+spdk_lcore_to_socket_id(unsigned lcore_id);
+
+
+/**
+ * Test if an lcore is enabled.
+ *
+ * \param lcore_id
+ *   The identifier of the lcore, which MUST be between 0 and
+ *   RTE_MAX_LCORE-1.
+ * \return
+ *   True if the given lcore is enabled; false otherwise.
+ */
+int
+spdk_lcore_is_enabled(unsigned lcore_id);
+
+/**
+ * Return the number of execution units (lcores) on the system.
+ *
+ * \return
+ *   the number of execution units (lcores) on the system.
+ */
+unsigned
+spdk_lcore_count(void);
+
+/**
+ * Get the next enabled lcore ID.
+ *
+ * \param i
+ *   The current lcore (reference).
+ * \param skip_master
+ *   If true, do not return the ID of the master lcore.
+ * \param wrap
+ *   If true, go back to 0 when SPDK_MAX_LCORE is reached; otherwise,
+ *   return SPDK_MAX_LCORE.
+ * \return
+ *   The next lcore_id or SPDK_MAX_LCORE if not found.
+ */
+unsigned
+spdk_get_next_lcore(unsigned i, int skip_master, int wrap);
+
+/**
+ * Macro to browse all running lcores.
+ */
+#define SPDK_LCORE_FOREACH(i)						\
+	for (i = spdk_get_next_lcore(-1, 0, 0);				\
+	     i<SPDK_MAX_LCORE;						\
+	     i = spdk_get_next_lcore(i, 0, 0))
+
+/**
+ * Macro to browse all running lcores except the master lcore.
+ */
+#define SPDK_LCORE_FOREACH_SLAVE(i)					\
+	for (i = spdk_get_next_lcore(-1, 1, 0);				\
+	     i<SPDK_MAX_LCORE;						\
+	     i = spdk_get_next_lcore(i, 1, 0))
+
+/**
+ * Wait until a lcore finished its job.
+ */
+int
+spdk_wait_lcore(unsigned slave_id);
+
+/**
+ * Wait until on all the lcores.
+ */
+void
+spdk_mp_wait_lcore(void);
+
+/**
+ * Get the current state of the lcore.
+ */
+int
+spdk_get_lcore_state(unsigned lcore_id);
+
+/**
+ * Send a message to a slave lcore identified by slave_id to call a
+ * function f with argument arg. Once the execution is done, the
+ * remote lcore switch in FINISHED state.
+ */
+int
+spdk_remote_launch(int (*f)(void *), void *arg, unsigned slave_id);
+
 /**
  * Page-granularity memory address translation table
  */

--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -31,6 +31,11 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
+ *   Copyright (c) 1992-2017 NetApp, Inc.
+ *   All rights reserved.
+ */
+
 /** \file
  * Encapsulated third-party dependencies
  */
@@ -322,6 +327,430 @@ int spdk_pci_addr_fmt(char *bdf, size_t sz, const struct spdk_pci_addr *addr);
  * \return the return value of cb()
  */
 void *spdk_call_unaffinitized(void *cb(void *arg), void *arg);
+
+struct spdk_ring;
+
+#define RING_F_SP_ENQ 0x0001 /**< The default enqueue is "single-producer". */
+#define RING_F_SC_DEQ 0x0002 /**< The default dequeue is "single-consumer". */
+
+/**
+ * Enqueue several objects on the ring (multi-producers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * producer index atomically.
+ *
+ * \param sr
+ *   A pointer to the spdk_ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects).
+ * \param n
+ *   The number of objects to add in the ring from the obj_table.
+ * \return
+ *   - 0: Success; objects enqueue.
+ *   - -EDQUOT: Quota exceeded. The objects have been enqueued, but the
+ *     high water mark is exceeded.
+ *   - -ENOBUFS: Not enough room in the ring to enqueue, no object is enqueued.
+ */
+int
+spdk_ring_mp_enqueue_bulk(struct spdk_ring *sr, void *const *obj_table,
+			  unsigned n);
+/**
+ * Enqueue several objects on a spdk ring (NOT multi-producers safe).
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects).
+ * \param n
+ *   The number of objects to add in the ring from the obj_table.
+ * \return
+ *   - 0: Success; objects enqueued.
+ *   - -EDQUOT: Quota exceeded. The objects have been enqueued, but the
+ *     high water mark is exceeded.
+ *   - -ENOBUFS: Not enough room in the ring to enqueue; no object is enqueued.
+ */
+int
+spdk_ring_sp_enqueue_bulk(struct spdk_ring *sr, void *const *obj_table,
+			  unsigned n);
+
+/**
+ * Enqueue several objects on a spdk ring.
+ *
+ * This function calls the multi-producer or the single-producer
+ * version depending on the default behavior that was specified at
+ * ring creation time (see flags).
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects).
+ * \param n
+ *   The number of objects to add in the ring from the obj_table.
+ * \return
+ *   - 0: Success; objects enqueued.
+ *   - -EDQUOT: Quota exceeded. The objects have been enqueued, but the
+ *     high water mark is exceeded.
+ *   - -ENOBUFS: Not enough room in the ring to enqueue; no object is enqueued.
+ */
+int
+spdk_ring_enqueue_bulk(struct spdk_ring *sr, void *const *obj_table,
+		       unsigned n);
+/**
+ * Enqueue one object on a spdk ring (multi-producers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * producer index atomically.
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj
+ *   A pointer to the object to be added.
+ * \return
+ *   - 0: Success; objects enqueued.
+ *   - -EDQUOT: Quota exceeded. The objects have been enqueued, but the
+ *     high water mark is exceeded.
+ *   - -ENOBUFS: Not enough room in the ring to enqueue; no object is enqueued.
+ */
+int
+spdk_ring_mp_enqueue(struct spdk_ring *sr, void *obj);
+
+/**
+ * Enqueue one object on a spdk ring (NOT multi-producers safe).
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj
+ *   A pointer to the object to be added.
+ * \return
+ *   - 0: Success; objects enqueued.
+ *   - -EDQUOT: Quota exceeded. The objects have been enqueued, but the
+ *     high water mark is exceeded.
+ *   - -ENOBUFS: Not enough room in the ring to enqueue; no object is enqueued.
+ */
+int
+spdk_ring_sp_enqueue(struct spdk_ring *sr, void *obj);
+
+/**
+ * Enqueue one object on a spdk ring.
+ *
+ * This function calls the multi-producer or the single-producer
+ * version, depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj
+ *   A pointer to the object to be added.
+ * \return
+ *   - 0: Success; objects enqueued.
+ *   - -EDQUOT: Quota exceeded. The objects have been enqueued, but the
+ *     high water mark is exceeded.
+ *   - -ENOBUFS: Not enough room in the ring to enqueue; no object is enqueued.
+ */
+int
+spdk_ring_enqueue(struct spdk_ring *sr, void *obj);
+
+/**
+ * Dequeue several objects from a spdk  ring (multi-consumers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * consumer index atomically.
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects) that will be filled.
+ * \param n
+ *   The number of objects to dequeue from the ring to the obj_table.
+ * \return
+ *   - 0: Success; objects dequeued.
+ *   - -ENOENT: Not enough entries in the ring to dequeue; no object is
+ *     dequeued.
+ */
+int
+spdk_ring_mc_dequeue_bulk(struct spdk_ring *sr, void **obj_table, unsigned n);
+
+/**
+ * Dequeue several objects from a spdk ring (NOT multi-consumers safe).
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects) that will be filled.
+ * \param n
+ *   The number of objects to dequeue from the ring to the obj_table,
+ *   must be strictly positive.
+ * \return
+ *   - 0: Success; objects dequeued.
+ *   - -ENOENT: Not enough entries in the ring to dequeue; no object is
+ *     dequeued.
+ */
+int
+spdk_ring_sc_dequeue_bulk(struct spdk_ring *sr, void **obj_table, unsigned n);
+
+/**
+ * Dequeue several objects from a spdk ring.
+ *
+ * This function calls the multi-consumers or the single-consumer
+ * version, depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ * \param sr
+ *   A pointer to the ring spdk structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects) that will be filled.
+ * \param n
+ *   The number of objects to dequeue from the ring to the obj_table.
+ * \return
+ *   - 0: Success; objects dequeued.
+ *   - -ENOENT: Not enough entries in the ring to dequeue, no object is
+ *     dequeued.
+ */
+int
+spdk_ring_dequeue_bulk(struct spdk_ring *sr, void **obj_table, unsigned n);
+
+/**
+ * Dequeue one object from a spdk ring (multi-consumers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * consumer index atomically.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_p
+ *   A pointer to a void * pointer (object) that will be filled.
+ * \return
+ *   - 0: Success; objects dequeued.
+ *   - -ENOENT: Not enough entries in the ring to dequeue; no object is
+ *     dequeued.
+ */
+int
+spdk_ring_mc_dequeue(struct spdk_ring *sr, void **obj_p);
+/**
+ * Dequeue one object from a spdk ring (NOT multi-consumers safe).
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_p
+ *   A pointer to a void * pointer (object) that will be filled.
+ * \return
+ *   - 0: Success; objects dequeued.
+ *   - -ENOENT: Not enough entries in the ring to dequeue, no object is
+ *     dequeued.
+ */
+int
+spdk_ring_sc_dequeue(struct spdk_ring *sr, void **obj_p);
+
+/**
+ * Dequeue one object from a spdk ring.
+ *
+ * This function calls the multi-consumers or the single-consumer
+ * version depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_p
+ *   A pointer to a void * pointer (object) that will be filled.
+ * \return
+ *   - 0: Success, objects dequeued.
+ *   - -ENOENT: Not enough entries in the ring to dequeue, no object is
+ *     dequeued.
+ */
+int
+spdk_ring_dequeue(struct spdk_ring *sr, void **obj_p);
+
+/**
+ * Test if a spdk ring is full.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \return
+ *   - 1: The ring is full.
+ *   - 0: The ring is not full.
+ */
+int
+spdk_ring_full(const struct spdk_ring *sr);
+
+/**
+ * Test if a spdk ring is empty.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \return
+ *   - 1: The ring is empty.
+ *   - 0: The ring is not empty.
+ */
+int
+spdk_ring_empty(const struct spdk_ring *sr);
+
+/**
+ * Return the number of entries in a spdk ring.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \return
+ *   The number of entries in the ring.
+ */
+unsigned
+spdk_ring_count(const struct spdk_ring *sr);
+
+/**
+ * Return the number of free entries in a spdk ring.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \return
+ *   The number of free entries in the ring.
+ */
+unsigned
+spdk_ring_free_count(const struct spdk_ring *sr);
+
+/**
+ * Enqueue several objects on the ring (multi-producers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * producer index atomically.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects).
+ * \param n
+ *   The number of objects to add in the ring from the obj_table.
+ * \return
+ *   - n: Actual number of objects enqueued.
+ */
+unsigned
+spdk_ring_mp_enqueue_burst(struct spdk_ring *sr, void *const *obj_table,
+			   unsigned n);
+
+/**
+ * Enqueue several objects on a spdk ring (NOT multi-producers safe).
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects).
+ * \param n
+ *   The number of objects to add in the ring from the obj_table.
+ * \return
+ *   - n: Actual number of objects enqueued.
+ */
+unsigned
+spdk_ring_sp_enqueue_burst(struct spdk_ring *sr, void *const *obj_table,
+			   unsigned n);
+/**
+ * Enqueue several objects on a spdk ring.
+ *
+ * This function calls the multi-producer or the single-producer
+ * version depending on the default behavior that was specified at
+ * ring creation time (see flags).
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects).
+ * \param n
+ *   The number of objects to add in the ring from the obj_table.
+ * \return
+ *   - n: Actual number of objects enqueued.
+ */
+unsigned
+spdk_ring_enqueue_burst(struct spdk_ring *sr, void *const *obj_table,
+			unsigned n);
+/**
+ * Dequeue several objects from a spdk ring (multi-consumers safe). When the request
+ * objects are more than the available objects, only dequeue the actual number
+ * of objects
+ *
+ * This function uses a "compare and set" instruction to move the
+ * consumer index atomically.
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects) that will be filled.
+ * \param n
+ *   The number of objects to dequeue from the ring to the obj_table.
+ * \return
+ *   - n: Actual number of objects dequeued, 0 if ring is empty
+ */
+unsigned
+spdk_ring_mc_dequeue_burst(struct spdk_ring *sr, void **obj_table, unsigned n);
+
+/**
+ * Dequeue several objects from a spdk ring (NOT multi-consumers safe).When the
+ * request objects are more than the available objects, only dequeue the
+ * actual number of objects
+ *
+ * \param sr
+ *   A pointer to the ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects) that will be filled.
+ * \param n
+ *   The number of objects to dequeue from the ring to the obj_table.
+ * \return
+ *   - n: Actual number of objects dequeued, 0 if ring is empty
+ */
+unsigned
+spdk_ring_sc_dequeue_burst(struct spdk_ring *sr, void **obj_table, unsigned n);
+
+/**
+ * Dequeue multiple objects from a spdk ring up to a maximum number.
+ *
+ * This function calls the multi-consumers or the single-consumer
+ * version, depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ * \param sr
+ *   A pointer to the spdk ring structure.
+ * \param obj_table
+ *   A pointer to a table of void * pointers (objects) that will be filled.
+ * \param n
+ *   The number of objects to dequeue from the ring to the obj_table.
+ * \return
+ *   - Number of objects dequeued
+ */
+unsigned
+spdk_ring_dequeue_burst(struct spdk_ring *sr, void **obj_table, unsigned n);
+
+/**
+ * return the size of memory occupied by a ring
+ */
+ssize_t spdk_ring_get_memsize(unsigned count);
+
+/**
+ * Create a ring
+ */
+struct spdk_ring *
+spdk_ring_create(const char *name, unsigned count, int socket_id, unsigned flags);
+
+/**
+ * free the ring
+ */
+void spdk_ring_free(struct spdk_ring *sr);
+
+/**
+ * Change the high water mark. If *count* is 0, water marking is
+ * disabled
+ */
+int spdk_ring_set_water_mark(struct spdk_ring *sr, unsigned count);
+
+/**
+ * dump the status of the ring on the console
+ */
+void spdk_ring_dump(FILE *f, const struct spdk_ring *sr);
+
+/**
+ * dump the status of all rings on the console
+ */
+void spdk_ring_list_dump(FILE *f);
+
+/**
+ * search a ring from its name
+ */
+struct spdk_ring *spdk_ring_lookup(const char *name);
 
 /**
  * Page-granularity memory address translation table

--- a/lib/copy/copy_engine.c
+++ b/lib/copy/copy_engine.c
@@ -37,9 +37,7 @@
 #include <stdio.h>
 #include <errno.h>
 
-#include <rte_config.h>
-#include <rte_memcpy.h>
-
+#include "spdk/env.h"
 #include "spdk/log.h"
 #include "spdk/io_channel.h"
 
@@ -112,7 +110,8 @@ mem_copy_submit(void *cb_arg, struct spdk_io_channel *ch, void *dst, void *src, 
 {
 	struct spdk_copy_task *copy_req;
 
-	rte_memcpy(dst, src, (size_t)nbytes);
+	spdk_memcpy(dst, src, (size_t)nbytes);
+
 	copy_req = (struct spdk_copy_task *)((uintptr_t)cb_arg -
 					     offsetof(struct spdk_copy_task, offload_ctx));
 	cb(copy_req, 0);

--- a/lib/env_dpdk/env.c
+++ b/lib/env_dpdk/env.c
@@ -357,6 +357,15 @@ spdk_remote_launch(int (*f)(void *), void *arg, unsigned slave_id)
 	return rte_eal_remote_launch(f, arg, slave_id);
 }
 
+/**
+ * Memcpy
+ */
+void
+spdk_memcpy(void *dst, const void *src, int len)
+{
+	rte_memcpy(dst, src, len);
+}
+
 extern struct rte_tailq_elem rte_ring_tailq;
 
 /**

--- a/lib/env_dpdk/env.c
+++ b/lib/env_dpdk/env.c
@@ -55,6 +55,8 @@
  */
 
 static_assert(SPDK_MAX_LCORE == RTE_MAX_LCORE, "SPDK_MAX_LCORE != RTE_MAX_LCORE");
+static_assert(SPDK_MEMPOOL_CACHE_MAX_SIZE == RTE_MEMPOOL_CACHE_MAX_SIZE,
+	      "SPDK_MEMPOOL_CACHE_MAX_SIZE != RTE_MEMPOOL_CACHE_MAX_SIZE");
 
 void *
 spdk_malloc(size_t size, size_t align, uint64_t *phys_addr)
@@ -197,6 +199,16 @@ void
 spdk_mempool_put_bulk(struct spdk_mempool *mp, void *const *ele_arr, size_t count)
 {
 	rte_mempool_put_bulk((struct rte_mempool *)mp, ele_arr, count);
+}
+
+unsigned
+spdk_mempool_avail_count(const struct spdk_mempool *pool)
+{
+#if RTE_VERSION < RTE_VERSION_NUM(16, 7, 0, 1)
+	return rte_mempool_count((struct rte_mempool *)pool);
+#else
+	return rte_mempool_avail_count((struct rte_mempool *)pool);
+#endif
 }
 
 bool

--- a/lib/env_dpdk/env.c
+++ b/lib/env_dpdk/env.c
@@ -31,8 +31,13 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "spdk/env.h"
+/*
+ *   Copyright (c) 1992-2017 NetApp, Inc.
+ *   All rights reserved.
+ */
 
+
+#include "spdk/env.h"
 #include <string.h>
 #include <unistd.h>
 
@@ -236,4 +241,361 @@ spdk_call_unaffinitized(void *cb(void *arg), void *arg)
 	rte_thread_set_affinity(&orig_cpuset);
 
 	return ret;
+}
+
+extern struct rte_tailq_elem rte_ring_tailq;
+
+/**
+ * Enqueue several objects on the ring (multi-producers safe).
+ *
+ */
+int
+spdk_ring_mp_enqueue_bulk(struct spdk_ring *sr, void *const *obj_table,
+			  unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_mp_enqueue_bulk(r, obj_table, n);
+}
+
+/**
+ * Enqueue several objects on a spdk ring (NOT multi-producers safe).
+ *
+ */
+int
+spdk_ring_sp_enqueue_bulk(struct spdk_ring *sr, void *const *obj_table,
+			  unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_sp_enqueue_bulk(r, obj_table, n);
+}
+
+/**
+ * Enqueue several objects on a spdk ring.
+ *
+ * This function calls the multi-producer or the single-producer
+ * version depending on the default behavior that was specified at
+ * ring creation time (see flags).
+ *
+ */
+int
+spdk_ring_enqueue_bulk(struct spdk_ring *sr, void *const *obj_table,
+		       unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_enqueue_bulk(r, obj_table, n);
+}
+
+/**
+ * Enqueue one object on a spdk ring (multi-producers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * producer index atomically.
+ *
+ */
+int
+spdk_ring_mp_enqueue(struct spdk_ring *sr, void *obj)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_mp_enqueue(r, obj);
+}
+
+/**
+ * Enqueue one object on a spdk ring (NOT multi-producers safe).
+ *
+ */
+int
+spdk_ring_sp_enqueue(struct spdk_ring *sr, void *obj)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_sp_enqueue(r, obj);
+}
+
+/**
+ * Enqueue one object on a spdk ring.
+ *
+ * This function calls the multi-producer or the single-producer
+ * version, depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ */
+int
+spdk_ring_enqueue(struct spdk_ring *sr, void *obj)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_enqueue(r, obj);
+}
+
+/**
+ * Dequeue several objects from a spdk	ring (multi-consumers safe).
+ *
+ */
+int
+spdk_ring_mc_dequeue_bulk(struct spdk_ring *sr, void **obj_table, unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_mc_dequeue_bulk(r, obj_table, n);
+}
+
+/**
+ * Dequeue several objects from a spdk ring (NOT multi-consumers safe).
+ *
+ */
+int
+spdk_ring_sc_dequeue_bulk(struct spdk_ring *sr, void **obj_table, unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_sc_dequeue_bulk(r, obj_table, n);
+}
+
+/**
+ * Dequeue several objects from a spdk ring.
+ *
+ * This function calls the multi-consumers or the single-consumer
+ * version, depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ */
+int
+spdk_ring_dequeue_bulk(struct spdk_ring *sr, void **obj_table, unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_dequeue_bulk(r, obj_table, n);
+}
+
+/**
+ * Dequeue one object from a spdk ring (multi-consumers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * consumer index atomically.
+ *
+ */
+int
+spdk_ring_mc_dequeue(struct spdk_ring *sr, void **obj_p)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_mc_dequeue(r, obj_p);
+}
+
+/**
+ * Dequeue one object from a spdk ring (NOT multi-consumers safe).
+ *
+ */
+int
+spdk_ring_sc_dequeue(struct spdk_ring *sr, void **obj_p)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_sc_dequeue(r, obj_p);
+}
+
+/**
+ * Dequeue one object from a spdk ring.
+ *
+ * This function calls the multi-consumers or the single-consumer
+ * version depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ *
+ */
+int
+spdk_ring_dequeue(struct spdk_ring *sr, void **obj_p)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_dequeue(r, obj_p);
+}
+
+/**
+ * Test if a spdk ring is full.
+ *
+ */
+int
+spdk_ring_full(const struct spdk_ring *sr)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_full(r);
+}
+
+/**
+ * Test if a spdk ring is empty.
+ *
+ */
+int
+spdk_ring_empty(const struct spdk_ring *sr)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_empty(r);
+}
+
+/**
+ * Return the number of entries in a spdk ring.
+ *
+ */
+unsigned
+spdk_ring_count(const struct spdk_ring *sr)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_count(r);
+}
+
+/**
+ * Return the number of free entries in a spdk ring.
+ *
+ */
+unsigned
+spdk_ring_free_count(const struct spdk_ring *sr)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_free_count(r);
+}
+
+/**
+ * Enqueue several objects on the ring (multi-producers safe).
+ *
+ * This function uses a "compare and set" instruction to move the
+ * producer index atomically.
+ *
+ */
+unsigned
+spdk_ring_mp_enqueue_burst(struct spdk_ring *sr, void *const *obj_table,
+			   unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_mp_enqueue_burst(r, obj_table, n);
+}
+
+/**
+ * Enqueue several objects on a spdk ring (NOT multi-producers safe).
+ *
+ */
+unsigned
+spdk_ring_sp_enqueue_burst(struct spdk_ring *sr, void *const *obj_table,
+			   unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_sp_enqueue_burst(r, obj_table, n);
+}
+
+/**
+ * Enqueue several objects on a spdk ring.
+ *
+ * This function calls the multi-producer or the single-producer
+ * version depending on the default behavior that was specified at
+ * ring creation time (see flags).
+ *
+ */
+unsigned
+spdk_ring_enqueue_burst(struct spdk_ring *sr, void *const *obj_table,
+			unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_enqueue_burst(r, obj_table, n);
+}
+
+/**
+ * Dequeue several objects from a spdk ring (multi-consumers safe). When the request
+ * objects are more than the available objects, only dequeue the actual number
+ * of objects
+ *
+ * This function uses a "compare and set" instruction to move the
+ * consumer index atomically.
+ *
+ */
+unsigned
+spdk_ring_mc_dequeue_burst(struct spdk_ring *sr, void **obj_table, unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_mc_dequeue_burst(r, obj_table, n);
+}
+
+/**
+ * Dequeue several objects from a spdk ring (NOT multi-consumers safe).When the
+ * request objects are more than the available objects, only dequeue the
+ * actual number of objects
+ */
+unsigned
+spdk_ring_sc_dequeue_burst(struct spdk_ring *sr, void **obj_table, unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_sc_dequeue_burst(r, obj_table, n);
+}
+
+/**
+ * Dequeue multiple objects from a spdk ring up to a maximum number.
+ *
+ * This function calls the multi-consumers or the single-consumer
+ * version, depending on the default behaviour that was specified at
+ * ring creation time (see flags).
+ */
+unsigned
+spdk_ring_dequeue_burst(struct spdk_ring *sr, void **obj_table, unsigned n)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_dequeue_burst(r, obj_table, n);
+}
+
+
+/**
+ * Return the size of memory occupied by a ring
+ */
+ssize_t
+spdk_ring_get_memsize(unsigned count)
+{
+	return rte_ring_get_memsize(count);
+}
+
+/**
+ * Create a ring
+ */
+struct spdk_ring *
+spdk_ring_create(const char *name, unsigned count, int socket_id,
+		 unsigned flags)
+{
+	return (struct spdk_ring *) rte_ring_create(name, count, socket_id, flags);
+}
+
+/**
+ * Free the ring
+ */
+void
+spdk_ring_free(struct spdk_ring *sr)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	rte_ring_free(r);
+}
+
+/**
+ * Change the high water mark. If *count* is 0, water marking is
+ * disabled
+ */
+int
+spdk_ring_set_water_mark(struct spdk_ring *sr, unsigned count)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	return rte_ring_set_water_mark(r, count);
+}
+
+/**
+ *  Dump the status of the ring on the console
+ */
+void
+spdk_ring_dump(FILE *f, const struct spdk_ring *sr)
+{
+	struct rte_ring *r = (struct rte_ring *)sr;
+	rte_ring_dump(f, r);
+}
+
+/**
+ * Dump the status of all rings on the console
+ */
+void
+spdk_ring_list_dump(FILE *f)
+{
+	rte_ring_list_dump(f);
+}
+
+/**
+ * Search a ring from its name
+ */
+struct spdk_ring *
+spdk_ring_lookup(const char *name)
+{
+	return (struct spdk_ring *)rte_ring_lookup(name);
 }

--- a/lib/env_dpdk/env.c
+++ b/lib/env_dpdk/env.c
@@ -40,6 +40,7 @@
 #include "spdk/env.h"
 #include <string.h>
 #include <unistd.h>
+#include <assert.h>
 
 #include <rte_config.h>
 #include <rte_cycles.h>
@@ -47,6 +48,13 @@
 #include <rte_mempool.h>
 #include <rte_memzone.h>
 #include <rte_version.h>
+#include <rte_lcore.h>
+
+/*
+ * Insure the definitions in spdk/env.h are equivelant to the DPDK definitions.
+ */
+
+static_assert(SPDK_MAX_LCORE == RTE_MAX_LCORE, "SPDK_MAX_LCORE != RTE_MAX_LCORE");
 
 void *
 spdk_malloc(size_t size, size_t align, uint64_t *phys_addr)
@@ -241,6 +249,100 @@ spdk_call_unaffinitized(void *cb(void *arg), void *arg)
 	rte_thread_set_affinity(&orig_cpuset);
 
 	return ret;
+}
+
+/**
+ * Return the ID of the execution unit we are running on.
+ */
+unsigned
+spdk_lcore_id(void)
+{
+	return rte_lcore_id();
+}
+
+/**
+ * Get the id of the master lcore
+ */
+unsigned
+spdk_get_master_lcore(void)
+{
+	return rte_get_master_lcore();
+}
+
+/**
+ * Get the ID of the physical socket of the specified lcore
+ */
+unsigned
+spdk_lcore_to_socket_id(unsigned lcore_id)
+{
+	return rte_lcore_to_socket_id(lcore_id);
+}
+
+/**
+ * Test if an lcore is enabled.
+ */
+int
+spdk_lcore_is_enabled(unsigned lcore_id)
+{
+	return rte_lcore_is_enabled(lcore_id);
+}
+
+/**
+ * Return the number of execution units (lcores) on the system.
+ */
+unsigned
+spdk_lcore_count(void)
+{
+	return rte_lcore_count();
+}
+
+/**
+ * Get the next enabled lcore ID.
+ */
+unsigned
+spdk_get_next_lcore(unsigned i, int skip_master, int wrap)
+{
+	return rte_get_next_lcore(i, skip_master, wrap);
+}
+
+
+/**
+ * Wait for all  lcores to finish processing their jobs.
+ */
+void
+spdk_mp_wait_lcore(void)
+{
+	rte_eal_mp_wait_lcore();
+}
+
+/**
+ * Return the state of the lcore identified by slave_id.
+ */
+int
+spdk_get_lcore_state(unsigned lcore_id)
+{
+	return (int) rte_eal_get_lcore_state(lcore_id);
+}
+
+
+/**
+ * Wait until a lcore finished its job.
+ */
+int
+spdk_wait_lcore(unsigned slave_id)
+{
+	return rte_eal_wait_lcore(slave_id);
+}
+
+/**
+ * Send a message to a slave lcore identified by slave_id to call a
+ * function f with argument arg. Once the execution is done, the
+ * remote lcore switch in FINISHED state.
+ */
+int
+spdk_remote_launch(int (*f)(void *), void *arg, unsigned slave_id)
+{
+	return rte_eal_remote_launch(f, arg, slave_id);
 }
 
 extern struct rte_tailq_elem rte_ring_tailq;

--- a/lib/event/app.c
+++ b/lib/event/app.c
@@ -240,12 +240,14 @@ spdk_app_init(struct spdk_app_opts *opts)
 	char			*end;
 	struct spdk_env_opts env_opts = {};
 
+#ifndef SPDK_NO_RLIMIT
 	if (opts->enable_coredump) {
 		struct rlimit core_limits;
 
 		core_limits.rlim_cur = core_limits.rlim_max = RLIM_INFINITY;
 		setrlimit(RLIMIT_CORE, &core_limits);
 	}
+#endif
 
 	config = spdk_conf_allocate();
 	assert(config != NULL);

--- a/lib/event/app.c
+++ b/lib/event/app.c
@@ -46,9 +46,6 @@
 #include <fcntl.h>
 #include <signal.h>
 
-#include <rte_config.h>
-#include <rte_lcore.h>
-
 #include "spdk/env.h"
 #include "spdk/log.h"
 #include "spdk/conf.h"
@@ -352,7 +349,7 @@ spdk_app_init(struct spdk_app_opts *opts)
 	}
 
 	if (opts->shutdown_cb != NULL) {
-		g_shutdown_event = spdk_event_allocate(rte_lcore_id(), __shutdown_event_cb,
+		g_shutdown_event = spdk_event_allocate(spdk_lcore_id(), __shutdown_event_cb,
 						       NULL, NULL);
 
 		sigact.sa_handler = __shutdown_signal;
@@ -446,7 +443,7 @@ spdk_app_start(spdk_event_fn start_fn, void *arg1, void *arg2)
 
 	g_spdk_app.rc = 0;
 
-	event = spdk_event_allocate(rte_get_master_lcore(), start_fn,
+	event = spdk_event_allocate(spdk_get_master_lcore(), start_fn,
 				    arg1, arg2);
 	/* Queues up the event, but can't run it until the reactors start */
 	spdk_event_call(event);

--- a/lib/event/reactor.c
+++ b/lib/event/reactor.c
@@ -51,7 +51,6 @@
 
 #include <rte_config.h>
 #include <rte_launch.h>
-#include <rte_lcore.h>
 
 #include "spdk/log.h"
 #include "spdk/io_channel.h"
@@ -125,7 +124,7 @@ struct spdk_reactor {
 	uint64_t					max_delay_us;
 } __attribute__((aligned(64)));
 
-static struct spdk_reactor g_reactors[RTE_MAX_LCORE];
+static struct spdk_reactor g_reactors[SPDK_MAX_LCORE];
 
 static enum spdk_reactor_state	g_reactor_state = SPDK_REACTOR_STATE_INVALID;
 
@@ -431,14 +430,14 @@ spdk_reactor_construct(struct spdk_reactor *reactor, uint32_t lcore, uint64_t ma
 static void
 spdk_reactor_start(struct spdk_reactor *reactor)
 {
-	if (reactor->lcore != rte_get_master_lcore()) {
-		switch (rte_eal_get_lcore_state(reactor->lcore)) {
+	if (reactor->lcore != spdk_get_master_lcore()) {
+        switch (spdk_get_lcore_state(reactor->lcore)) {
 		case FINISHED:
-			rte_eal_wait_lcore(reactor->lcore);
+			spdk_wait_lcore(reactor->lcore);
 		/* drop through */
 		case WAIT:
-			rte_eal_remote_launch(_spdk_reactor_run, (void *)reactor, reactor->lcore);
-			break;
+			spdk_remote_launch(_spdk_reactor_run, (void *)reactor, reactor->lcore);
+            break;
 		case RUNNING:
 			printf("Something already running on lcore %d\n", reactor->lcore);
 			break;
@@ -476,8 +475,8 @@ spdk_app_parse_core_mask(const char *mask, uint64_t *cpumask)
 		return -1;
 	}
 
-	for (i = 0; i < RTE_MAX_LCORE && i < 64; i++) {
-		if ((*cpumask & (1ULL << i)) && !rte_lcore_is_enabled(i)) {
+	for (i = 0; i < SPDK_MAX_LCORE && i < 64; i++) {
+		if ((*cpumask & (1ULL << i)) && !spdk_lcore_is_enabled(i)) {
 			*cpumask &= ~(1ULL << i);
 		}
 	}
@@ -520,7 +519,7 @@ spdk_reactors_start(void)
 	struct spdk_reactor *reactor;
 	uint32_t i, current_core;
 
-	assert(rte_get_master_lcore() == rte_lcore_id());
+	assert(spdk_get_master_lcore() == spdk_lcore_id());
 
 	g_reactor_state = SPDK_REACTOR_STATE_RUNNING;
 
@@ -536,7 +535,7 @@ spdk_reactors_start(void)
 	reactor = spdk_reactor_get(current_core);
 	spdk_reactor_start(reactor);
 
-	rte_eal_mp_wait_lcore();
+	spdk_mp_wait_lcore();
 
 	g_reactor_state = SPDK_REACTOR_STATE_SHUTDOWN;
 }

--- a/lib/event/reactor.c
+++ b/lib/event/reactor.c
@@ -431,13 +431,13 @@ static void
 spdk_reactor_start(struct spdk_reactor *reactor)
 {
 	if (reactor->lcore != spdk_get_master_lcore()) {
-        switch (spdk_get_lcore_state(reactor->lcore)) {
+		switch (spdk_get_lcore_state(reactor->lcore)) {
 		case FINISHED:
 			spdk_wait_lcore(reactor->lcore);
 		/* drop through */
 		case WAIT:
 			spdk_remote_launch(_spdk_reactor_run, (void *)reactor, reactor->lcore);
-            break;
+			break;
 		case RUNNING:
 			printf("Something already running on lcore %d\n", reactor->lcore);
 			break;

--- a/test/lib/nvme/overhead/overhead.c
+++ b/test/lib/nvme/overhead/overhead.c
@@ -39,9 +39,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <rte_config.h>
-#include <rte_lcore.h>
-
 #include "spdk/barrier.h"
 #include "spdk/fd.h"
 #include "spdk/nvme.h"


### PR DESCRIPTION
    - Implemented a wrapper funtions for rte_config.h, rte_mempool.h, rte_lcore.h APIs.
    - Updated lib/env_dpdk with new spdk APIs to call rte functions
    - Changes to nvmf_tgt, event, reactor and app code to call the new
      spdk env wrapper functions instead of rte_ functions directly
