### PR TITLE
env: Reserve spdk_malloc/zmalloc/realloc/free for posix env.

### DIFF
--- a/examples/ioat/perf/perf.c
+++ b/examples/ioat/perf/perf.c
@@ -130,7 +130,7 @@ ioat_exit(void)
 		if (dev->ioat) {
 			spdk_ioat_detach(dev->ioat);
 		}
-		spdk_free(dev);
+		spdk_aligned_free(dev);
 	}
 }
 
@@ -226,7 +226,7 @@ attach_cb(void *cb_ctx, struct spdk_pci_device *pci_dev, struct spdk_ioat_chan *
 		return;
 	}
 
-	dev = spdk_zmalloc(sizeof(*dev), 0, NULL);
+	dev = spdk_aligned_zmalloc(sizeof(*dev), 0, NULL);
 	if (dev == NULL) {
 		printf("Failed to allocate device struct\n");
 		return;

--- a/examples/ioat/verify/verify.c
+++ b/examples/ioat/verify/verify.c
@@ -363,7 +363,7 @@ init_src_buffer(void)
 {
 	int i;
 
-	g_src = spdk_zmalloc(SRC_BUFFER_SIZE, 512, NULL);
+	g_src = spdk_aligned_zmalloc(SRC_BUFFER_SIZE, 512, NULL);
 	if (g_src == NULL) {
 		fprintf(stderr, "Allocate src buffer failed\n");
 		return -1;
@@ -480,7 +480,7 @@ main(int argc, char **argv)
 	rc = dump_result(threads, RTE_MAX_LCORE);
 
 cleanup:
-	spdk_free(g_src);
+	spdk_aligned_free(g_src);
 	ioat_exit();
 
 	return rc;

--- a/examples/nvme/arbitration/arbitration.c
+++ b/examples/nvme/arbitration/arbitration.c
@@ -300,9 +300,9 @@ static void
 task_ctor(struct rte_mempool *mp, void *arg, void *__task, unsigned id)
 {
 	struct arb_task *task = __task;
-	task->buf = spdk_zmalloc(g_arbitration.io_size_bytes, 0x200, NULL);
+	task->buf = spdk_aligned_zmalloc(g_arbitration.io_size_bytes, 0x200, NULL);
 	if (task->buf == NULL) {
-		fprintf(stderr, "task->buf spdk_zmalloc failed\n");
+		fprintf(stderr, "task->buf spdk_aligned_zmalloc failed\n");
 		exit(1);
 	}
 }
@@ -444,7 +444,7 @@ cleanup(void)
 	};
 
 	if (rte_mempool_get(task_pool, (void **)&task) == 0) {
-		spdk_free(task->buf);
+		spdk_aligned_free(task->buf);
 	}
 
 }

--- a/examples/nvme/fio_plugin/fio_plugin.c
+++ b/examples/nvme/fio_plugin/fio_plugin.c
@@ -313,13 +313,13 @@ static int spdk_fio_close(struct thread_data *td, struct fio_file *f)
 
 static int spdk_fio_iomem_alloc(struct thread_data *td, size_t total_mem)
 {
-	td->orig_buffer = spdk_zmalloc(total_mem, NVME_IO_ALIGN, NULL);
+	td->orig_buffer = spdk_aligned_zmalloc(total_mem, NVME_IO_ALIGN, NULL);
 	return td->orig_buffer == NULL;
 }
 
 static void spdk_fio_iomem_free(struct thread_data *td)
 {
-	spdk_free(td->orig_buffer);
+	spdk_aligned_free(td->orig_buffer);
 }
 
 static int spdk_fio_io_u_init(struct thread_data *td, struct io_u *io_u)

--- a/examples/nvme/hello_world/hello_world.c
+++ b/examples/nvme/hello_world/hello_world.c
@@ -111,7 +111,7 @@ read_complete(void *arg, const struct spdk_nvme_cpl *completion)
 	 *  to exit its polling loop.
 	 */
 	printf("%s", sequence->buf);
-	spdk_free(sequence->buf);
+	spdk_aligned_free(sequence->buf);
 	sequence->is_completed = 1;
 }
 
@@ -127,8 +127,8 @@ write_complete(void *arg, const struct spdk_nvme_cpl *completion)
 	 *  the write I/O and allocate a new zeroed buffer for reading
 	 *  the data back from the NVMe namespace.
 	 */
-	spdk_free(sequence->buf);
-	sequence->buf = spdk_zmalloc(0x1000, 0x1000, NULL);
+	spdk_aligned_free(sequence->buf);
+	sequence->buf = spdk_aligned_zmalloc(0x1000, 0x1000, NULL);
 
 	rc = spdk_nvme_ns_cmd_read(ns_entry->ns, ns_entry->qpair, sequence->buf,
 				   0, /* LBA start */
@@ -168,11 +168,11 @@ hello_world(void)
 		}
 
 		/*
-		 * Use spdk_zmalloc to allocate a 4KB zeroed buffer.  This memory
+		 * Use spdk_aligned_zmalloc to allocate a 4KB zeroed buffer.  This memory
 		 * will be pinned, which is required for data buffers used for SPDK NVMe
 		 * I/O operations.
 		 */
-		sequence.buf = spdk_zmalloc(0x1000, 0x1000, NULL);
+		sequence.buf = spdk_aligned_zmalloc(0x1000, 0x1000, NULL);
 		sequence.is_completed = 0;
 		sequence.ns_entry = ns_entry;
 

--- a/examples/nvme/hotplug/hotplug.c
+++ b/examples/nvme/hotplug/hotplug.c
@@ -154,7 +154,7 @@ unregister_dev(struct dev_ctx *dev)
 static void task_ctor(struct rte_mempool *mp, void *arg, void *__task, unsigned id)
 {
 	struct perf_task *task = __task;
-	task->buf = spdk_zmalloc(g_io_size_bytes, 0x200, NULL);
+	task->buf = spdk_aligned_zmalloc(g_io_size_bytes, 0x200, NULL);
 	if (task->buf == NULL) {
 		fprintf(stderr, "task->buf rte_malloc failed\n");
 		exit(1);

--- a/examples/nvme/nvme_manage/nvme_manage.c
+++ b/examples/nvme/nvme_manage/nvme_manage.c
@@ -89,7 +89,7 @@ identify_common_ns_cb(void *cb_arg, const struct spdk_nvme_cpl *cpl)
 
 	if (cpl->status.sc != SPDK_NVME_SC_SUCCESS) {
 		/* Identify Namespace for NSID = FFFFFFFFh is optional, so failure is not fatal. */
-		spdk_free(dev->common_ns_data);
+		spdk_aligned_free(dev->common_ns_data);
 		dev->common_ns_data = NULL;
 	}
 
@@ -111,7 +111,7 @@ attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid,
 	/* Retrieve controller data */
 	dev->cdata = spdk_nvme_ctrlr_get_data(dev->ctrlr);
 
-	dev->common_ns_data = spdk_zmalloc(sizeof(struct spdk_nvme_ns_data), 4096, NULL);
+	dev->common_ns_data = spdk_aligned_zmalloc(sizeof(struct spdk_nvme_ns_data), 4096, NULL);
 	if (dev->common_ns_data == NULL) {
 		fprintf(stderr, "common_ns_data allocation failure\n");
 		return;
@@ -127,7 +127,7 @@ attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid,
 	if (spdk_nvme_ctrlr_cmd_admin_raw(ctrlr, &cmd, dev->common_ns_data,
 					  sizeof(struct spdk_nvme_ns_data), identify_common_ns_cb, dev) != 0) {
 		dev->outstanding_admin_cmds--;
-		spdk_free(dev->common_ns_data);
+		spdk_aligned_free(dev->common_ns_data);
 		dev->common_ns_data = NULL;
 	}
 
@@ -366,7 +366,7 @@ get_allocated_nsid(struct dev *dev)
 	struct spdk_nvme_ns_list *ns_list;
 	struct spdk_nvme_cmd cmd = {0};
 
-	ns_list = spdk_zmalloc(sizeof(*ns_list), 4096, NULL);
+	ns_list = spdk_aligned_zmalloc(sizeof(*ns_list), 4096, NULL);
 	if (ns_list == NULL) {
 		printf("Allocation error\n");
 		return 0;
@@ -380,7 +380,7 @@ get_allocated_nsid(struct dev *dev)
 	if (spdk_nvme_ctrlr_cmd_admin_raw(dev->ctrlr, &cmd, ns_list, sizeof(*ns_list),
 					  identify_allocated_ns_cb, dev)) {
 		printf("Identify command failed\n");
-		spdk_free(ns_list);
+		spdk_aligned_free(ns_list);
 		return 0;
 	}
 
@@ -396,7 +396,7 @@ get_allocated_nsid(struct dev *dev)
 		printf("%u\n", ns_list->ns_list[i]);
 	}
 
-	spdk_free(ns_list);
+	spdk_aligned_free(ns_list);
 
 	printf("Please Input Namespace ID: \n");
 	if (!scanf("%u", &nsid)) {
@@ -413,7 +413,7 @@ ns_attach(struct dev *device, int attachment_op, int ctrlr_id, int ns_id)
 	int ret = 0;
 	struct spdk_nvme_ctrlr_list *ctrlr_list;
 
-	ctrlr_list = spdk_zmalloc(sizeof(struct spdk_nvme_ctrlr_list),
+	ctrlr_list = spdk_aligned_zmalloc(sizeof(struct spdk_nvme_ctrlr_list),
 				  4096, NULL);
 	if (ctrlr_list == NULL) {
 		printf("Allocation error (controller list)\n");
@@ -433,7 +433,7 @@ ns_attach(struct dev *device, int attachment_op, int ctrlr_id, int ns_id)
 		fprintf(stdout, "ns attach: Failed\n");
 	}
 
-	spdk_free(ctrlr_list);
+	spdk_aligned_free(ctrlr_list);
 }
 
 static void
@@ -443,7 +443,7 @@ ns_manage_add(struct dev *device, uint64_t ns_size, uint64_t ns_capacity, int ns
 	uint32_t nsid;
 	struct spdk_nvme_ns_data *ndata;
 
-	ndata = spdk_zmalloc(sizeof(struct spdk_nvme_ns_data), 4096, NULL);
+	ndata = spdk_aligned_zmalloc(sizeof(struct spdk_nvme_ns_data), 4096, NULL);
 	if (ndata == NULL) {
 		printf("Allocation error (namespace data)\n");
 		exit(1);
@@ -464,7 +464,7 @@ ns_manage_add(struct dev *device, uint64_t ns_size, uint64_t ns_capacity, int ns
 		printf("Created namespace ID %u\n", nsid);
 	}
 
-	spdk_free(ndata);
+	spdk_aligned_free(ndata);
 }
 
 static void
@@ -804,7 +804,7 @@ update_firmware_image(void)
 
 	size = fw_stat.st_size;
 
-	fw_image = spdk_zmalloc(size, 4096, NULL);
+	fw_image = spdk_aligned_zmalloc(size, 4096, NULL);
 	if (fw_image == NULL) {
 		printf("Allocation error\n");
 		close(fd);
@@ -814,7 +814,7 @@ update_firmware_image(void)
 	if (read(fd, fw_image, size) != ((ssize_t)(size))) {
 		printf("Read firmware image failed\n");
 		close(fd);
-		spdk_free(fw_image);
+		spdk_aligned_free(fw_image);
 		return;
 	}
 	close(fd);
@@ -822,7 +822,7 @@ update_firmware_image(void)
 	printf("Please Input Slot(0 - 7): \n");
 	if (!scanf("%d", &slot)) {
 		printf("Invalid Slot\n");
-		spdk_free(fw_image);
+		spdk_aligned_free(fw_image);
 		while (getchar() != '\n');
 		return;
 	}
@@ -833,7 +833,7 @@ update_firmware_image(void)
 	} else {
 		printf("spdk_nvme_ctrlr_update_firmware success\n");
 	}
-	spdk_free(fw_image);
+	spdk_aligned_free(fw_image);
 }
 
 int main(int argc, char **argv)

--- a/examples/nvme/perf/perf.c
+++ b/examples/nvme/perf/perf.c
@@ -269,7 +269,7 @@ register_ctrlr(struct spdk_nvme_ctrlr *ctrlr)
 		exit(1);
 	}
 
-	entry->latency_page = spdk_zmalloc(sizeof(struct spdk_nvme_intel_rw_latency_page),
+	entry->latency_page = spdk_aligned_zmalloc(sizeof(struct spdk_nvme_intel_rw_latency_page),
 					   4096, NULL);
 	if (entry->latency_page == NULL) {
 		printf("Allocation error (latency page)\n");
@@ -410,9 +410,9 @@ aio_check_io(struct ns_worker_ctx *ns_ctx)
 static void task_ctor(struct rte_mempool *mp, void *arg, void *__task, unsigned id)
 {
 	struct perf_task *task = __task;
-	task->buf = spdk_zmalloc(g_io_size_bytes, g_io_align, NULL);
+	task->buf = spdk_aligned_zmalloc(g_io_size_bytes, g_io_align, NULL);
 	if (task->buf == NULL) {
-		fprintf(stderr, "task->buf spdk_zmalloc failed\n");
+		fprintf(stderr, "task->buf spdk_aligned_zmalloc failed\n");
 		exit(1);
 	}
 	memset(task->buf, id % 8, g_io_size_bytes);
@@ -1130,7 +1130,7 @@ unregister_controllers(void)
 
 	while (entry) {
 		struct ctrlr_entry *next = entry->next;
-		spdk_free(entry->latency_page);
+		spdk_aligned_free(entry->latency_page);
 		if (g_latency_tracking_enable &&
 		    spdk_nvme_ctrlr_is_feature_supported(entry->ctrlr, SPDK_NVME_INTEL_FEAT_LATENCY_TRACKING))
 			set_latency_tracking_feature(entry->ctrlr, false);

--- a/include/spdk/env.h
+++ b/include/spdk/env.h
@@ -78,25 +78,25 @@ void spdk_env_init(const struct spdk_env_opts *opts);
  * Allocate a pinned, physically contiguous memory buffer with the
  *   given size and alignment.
  */
-void *spdk_malloc(size_t size, size_t align, uint64_t *phys_addr);
+void *spdk_aligned_malloc(size_t size, size_t align, uint64_t *phys_addr);
 
 /**
  * Allocate a pinned, physically contiguous memory buffer with the
  *   given size and alignment. The buffer will be zeroed.
  */
-void *spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr);
+void *spdk_aligned_zmalloc(size_t size, size_t align, uint64_t *phys_addr);
 
 /**
  * Resize the allocated and pinned memory buffer with the given
  *   new size and alignment. Existing contents are preserved.
  */
-void *spdk_realloc(void *buf, size_t size, size_t align, uint64_t *phys_addr);
+void *spdk_aligned_realloc(void *buf, size_t size, size_t align, uint64_t *phys_addr);
 
 /**
- * Free a memory buffer previously allocated with spdk_zmalloc.
+ * Free a memory buffer previously allocated with spdk_aligned_zmalloc.
  *   This call is never made from the performance path.
  */
-void spdk_free(void *buf);
+void spdk_aligned_free(void *buf);
 
 /**
  * Reserve a named, process shared memory zone with the given size,

--- a/lib/bdev/malloc/blockdev_malloc.c
+++ b/lib/bdev/malloc/blockdev_malloc.c
@@ -130,8 +130,8 @@ blockdev_malloc_destruct(void *ctx)
 {
 	struct malloc_disk *malloc_disk = ctx;
 	blockdev_malloc_delete_from_list(malloc_disk);
-	spdk_free(malloc_disk->malloc_buf);
-	spdk_free(malloc_disk);
+	spdk_aligned_free(malloc_disk->malloc_buf);
+	spdk_aligned_free(malloc_disk);
 	return 0;
 }
 
@@ -378,7 +378,7 @@ struct spdk_bdev *create_malloc_disk(uint64_t num_blocks, uint32_t block_size)
 		return NULL;
 	}
 
-	mdisk = spdk_zmalloc(sizeof(*mdisk), 0, NULL);
+	mdisk = spdk_aligned_zmalloc(sizeof(*mdisk), 0, NULL);
 	if (!mdisk) {
 		perror("mdisk");
 		return NULL;
@@ -390,10 +390,10 @@ struct spdk_bdev *create_malloc_disk(uint64_t num_blocks, uint32_t block_size)
 	 * TODO: need to pass a hint so we know which socket to allocate
 	 *  from on multi-socket systems.
 	 */
-	mdisk->malloc_buf = spdk_zmalloc(num_blocks * block_size, 2 * 1024 * 1024, NULL);
+	mdisk->malloc_buf = spdk_aligned_zmalloc(num_blocks * block_size, 2 * 1024 * 1024, NULL);
 	if (!mdisk->malloc_buf) {
-		SPDK_ERRLOG("spdk_zmalloc failed\n");
-		spdk_free(mdisk);
+		SPDK_ERRLOG("spdk_aligned_zmalloc failed\n");
+		spdk_aligned_free(mdisk);
 		return NULL;
 	}
 
@@ -420,8 +420,8 @@ struct spdk_bdev *create_malloc_disk(uint64_t num_blocks, uint32_t block_size)
 
 static void free_malloc_disk(struct malloc_disk *mdisk)
 {
-	spdk_free(mdisk->malloc_buf);
-	spdk_free(mdisk);
+	spdk_aligned_free(mdisk->malloc_buf);
+	spdk_aligned_free(mdisk);
 }
 
 static int blockdev_malloc_initialize(void)

--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -297,13 +297,13 @@ _spdk_blob_serialize_add_page(const struct spdk_blob *blob,
 	if (*page_count == 0) {
 		assert(*pages == NULL);
 		*page_count = 1;
-		*pages = spdk_malloc(sizeof(struct spdk_blob_md_page),
+		*pages = spdk_aligned_malloc(sizeof(struct spdk_blob_md_page),
 				     sizeof(struct spdk_blob_md_page),
 				     NULL);
 	} else {
 		assert(*pages != NULL);
 		(*page_count)++;
-		*pages = spdk_realloc(*pages,
+		*pages = spdk_aligned_realloc(*pages,
 				      sizeof(struct spdk_blob_md_page) * (*page_count),
 				      sizeof(struct spdk_blob_md_page),
 				      NULL);
@@ -457,7 +457,7 @@ _spdk_blob_serialize(const struct spdk_blob *blob, struct spdk_blob_md_page **pa
 			rc = _spdk_blob_serialize_add_page(blob, pages, page_count,
 							   &cur_page);
 			if (rc < 0) {
-				spdk_free(*pages);
+				spdk_aligned_free(*pages);
 				*pages = NULL;
 				*page_count = 0;
 				return rc;
@@ -473,7 +473,7 @@ _spdk_blob_serialize(const struct spdk_blob *blob, struct spdk_blob_md_page **pa
 							&required_sz);
 
 			if (rc < 0) {
-				spdk_free(*pages);
+				spdk_aligned_free(*pages);
 				*pages = NULL;
 				*page_count = 0;
 				return -1;
@@ -536,7 +536,7 @@ _spdk_blob_load_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 
 		/* Read the next page */
 		ctx->num_pages++;
-		ctx->pages = spdk_realloc(ctx->pages, (sizeof(*page) * ctx->num_pages),
+		ctx->pages = spdk_aligned_realloc(ctx->pages, (sizeof(*page) * ctx->num_pages),
 					  sizeof(*page), NULL);
 		if (ctx->pages == NULL) {
 			ctx->cb_fn(seq, ctx->cb_arg, -ENOMEM);
@@ -559,7 +559,7 @@ _spdk_blob_load_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 	ctx->cb_fn(seq, ctx->cb_arg, rc);
 
 	/* Free the memory */
-	spdk_free(ctx->pages);
+	spdk_aligned_free(ctx->pages);
 	free(ctx);
 }
 
@@ -586,7 +586,7 @@ _spdk_blob_load(spdk_bs_sequence_t *seq, struct spdk_blob *blob,
 	}
 
 	ctx->blob = blob;
-	ctx->pages = spdk_realloc(ctx->pages, sizeof(struct spdk_blob_md_page),
+	ctx->pages = spdk_aligned_realloc(ctx->pages, sizeof(struct spdk_blob_md_page),
 				  sizeof(struct spdk_blob_md_page), NULL);
 	if (!ctx->pages) {
 		free(ctx);
@@ -632,7 +632,7 @@ _spdk_blob_persist_complete(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 	ctx->cb_fn(seq, ctx->cb_arg, bserrno);
 
 	/* Free the memory */
-	spdk_free(ctx->pages);
+	spdk_aligned_free(ctx->pages);
 	free(ctx);
 }
 
@@ -959,7 +959,7 @@ _spdk_blob_persist(spdk_bs_sequence_t *seq, struct spdk_blob *blob,
 	for (i = 1; i < blob->active.num_pages; i++) {
 		page_num = spdk_bit_array_find_first_clear(bs->used_md_pages, page_num);
 		if (page_num >= spdk_bit_array_capacity(bs->used_md_pages)) {
-			spdk_free(ctx->pages);
+			spdk_aligned_free(ctx->pages);
 			free(ctx);
 			blob->state = SPDK_BLOB_STATE_DIRTY;
 			cb_fn(seq, cb_arg, -ENOMEM);
@@ -1181,8 +1181,8 @@ _spdk_bs_load_used_clusters_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserr
 
 	rc = spdk_bit_array_resize(&ctx->bs->used_clusters, ctx->bs->total_clusters);
 	if (rc < 0) {
-		spdk_free(ctx->super);
-		spdk_free(ctx->mask);
+		spdk_aligned_free(ctx->super);
+		spdk_aligned_free(ctx->mask);
 		_spdk_bs_free(ctx->bs);
 		free(ctx);
 		spdk_bs_sequence_finish(seq, -ENOMEM);
@@ -1202,8 +1202,8 @@ _spdk_bs_load_used_clusters_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserr
 		}
 	}
 
-	spdk_free(ctx->super);
-	spdk_free(ctx->mask);
+	spdk_aligned_free(ctx->super);
+	spdk_aligned_free(ctx->mask);
 	free(ctx);
 
 	spdk_bs_sequence_finish(seq, bserrno);
@@ -1227,8 +1227,8 @@ _spdk_bs_load_used_pages_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 
 	rc = spdk_bit_array_resize(&ctx->bs->used_md_pages, ctx->mask->length);
 	if (rc < 0) {
-		spdk_free(ctx->super);
-		spdk_free(ctx->mask);
+		spdk_aligned_free(ctx->super);
+		spdk_aligned_free(ctx->mask);
 		_spdk_bs_free(ctx->bs);
 		free(ctx);
 		spdk_bs_sequence_finish(seq, -ENOMEM);
@@ -1244,13 +1244,13 @@ _spdk_bs_load_used_pages_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 			segment >>= 1U;
 		}
 	}
-	spdk_free(ctx->mask);
+	spdk_aligned_free(ctx->mask);
 
 	/* Read the used clusters mask */
-	ctx->mask = spdk_zmalloc(ctx->super->used_cluster_mask_len * sizeof(struct spdk_blob_md_page),
+	ctx->mask = spdk_aligned_zmalloc(ctx->super->used_cluster_mask_len * sizeof(struct spdk_blob_md_page),
 				 0x1000, NULL);
 	if (!ctx->mask) {
-		spdk_free(ctx->super);
+		spdk_aligned_free(ctx->super);
 		_spdk_bs_free(ctx->bs);
 		free(ctx);
 		spdk_bs_sequence_finish(seq, -ENOMEM);
@@ -1269,7 +1269,7 @@ _spdk_bs_load_super_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 	uint64_t		lba, lba_count;
 
 	if (ctx->super->version != SPDK_BS_VERSION) {
-		spdk_free(ctx->super);
+		spdk_aligned_free(ctx->super);
 		_spdk_bs_free(ctx->bs);
 		free(ctx);
 		spdk_bs_sequence_finish(seq, -EILSEQ);
@@ -1278,7 +1278,7 @@ _spdk_bs_load_super_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 
 	if (memcmp(ctx->super->signature, SPDK_BS_SUPER_BLOCK_SIG,
 		   sizeof(ctx->super->signature)) != 0) {
-		spdk_free(ctx->super);
+		spdk_aligned_free(ctx->super);
 		_spdk_bs_free(ctx->bs);
 		free(ctx);
 		spdk_bs_sequence_finish(seq, -EILSEQ);
@@ -1291,7 +1291,7 @@ _spdk_bs_load_super_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 		 * on disk - the code just has not been written yet.
 		 */
 		assert(false);
-		spdk_free(ctx->super);
+		spdk_aligned_free(ctx->super);
 		_spdk_bs_free(ctx->bs);
 		free(ctx);
 		spdk_bs_sequence_finish(seq, -EILSEQ);
@@ -1307,10 +1307,10 @@ _spdk_bs_load_super_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrno)
 	ctx->bs->md_len = ctx->super->md_len;
 
 	/* Read the used pages mask */
-	ctx->mask = spdk_zmalloc(ctx->super->used_page_mask_len * sizeof(struct spdk_blob_md_page), 0x1000,
+	ctx->mask = spdk_aligned_zmalloc(ctx->super->used_page_mask_len * sizeof(struct spdk_blob_md_page), 0x1000,
 				 NULL);
 	if (!ctx->mask) {
-		spdk_free(ctx->super);
+		spdk_aligned_free(ctx->super);
 		_spdk_bs_free(ctx->bs);
 		free(ctx);
 		spdk_bs_sequence_finish(seq, -ENOMEM);
@@ -1352,7 +1352,7 @@ spdk_bs_load(struct spdk_bs_dev *dev,
 	ctx->bs = bs;
 
 	/* Allocate memory for the super block */
-	ctx->super = spdk_zmalloc(sizeof(*ctx->super), 0x1000, NULL);
+	ctx->super = spdk_aligned_zmalloc(sizeof(*ctx->super), 0x1000, NULL);
 	if (!ctx->super) {
 		free(ctx);
 		_spdk_bs_free(bs);
@@ -1366,7 +1366,7 @@ spdk_bs_load(struct spdk_bs_dev *dev,
 
 	seq = spdk_bs_sequence_start(bs->md_channel, &cpl);
 	if (!seq) {
-		spdk_free(ctx->super);
+		spdk_aligned_free(ctx->super);
 		free(ctx);
 		_spdk_bs_free(bs);
 		cb_fn(cb_arg, NULL, -ENOMEM);
@@ -1393,7 +1393,7 @@ _spdk_bs_init_persist_super_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserr
 {
 	struct spdk_bs_init_ctx *ctx = cb_arg;
 
-	spdk_free(ctx->super);
+	spdk_aligned_free(ctx->super);
 	free(ctx);
 
 	spdk_bs_sequence_finish(seq, bserrno);
@@ -1466,7 +1466,7 @@ spdk_bs_init(struct spdk_bs_dev *dev, struct spdk_bs_opts *o,
 	ctx->bs = bs;
 
 	/* Allocate memory for the super block */
-	ctx->super = spdk_zmalloc(sizeof(*ctx->super), 0x1000, NULL);
+	ctx->super = spdk_aligned_zmalloc(sizeof(*ctx->super), 0x1000, NULL);
 	if (!ctx->super) {
 		free(ctx);
 		_spdk_bs_free(bs);
@@ -1522,7 +1522,7 @@ spdk_bs_init(struct spdk_bs_dev *dev, struct spdk_bs_opts *o,
 
 	seq = spdk_bs_sequence_start(bs->md_channel, &cpl);
 	if (!seq) {
-		spdk_free(ctx->super);
+		spdk_aligned_free(ctx->super);
 		free(ctx);
 		_spdk_bs_free(bs);
 		cb_fn(cb_arg, NULL, -ENOMEM);
@@ -1549,7 +1549,7 @@ _spdk_bs_unload_write_super_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserr
 {
 	struct spdk_bs_unload_ctx	*ctx = cb_arg;
 
-	spdk_free(ctx->super);
+	spdk_aligned_free(ctx->super);
 
 	spdk_bs_sequence_finish(seq, bserrno);
 
@@ -1562,7 +1562,7 @@ _spdk_bs_unload_write_used_clusters_cpl(spdk_bs_sequence_t *seq, void *cb_arg, i
 {
 	struct spdk_bs_unload_ctx	*ctx = cb_arg;
 
-	spdk_free(ctx->mask);
+	spdk_aligned_free(ctx->mask);
 
 	/* Update the values in the super block */
 	ctx->super->super_blob = ctx->bs->super_blob;
@@ -1580,13 +1580,13 @@ _spdk_bs_unload_write_used_pages_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int 
 	uint32_t			i;
 	uint64_t			lba, lba_count;
 
-	spdk_free(ctx->mask);
+	spdk_aligned_free(ctx->mask);
 
 	/* Write out the used clusters mask */
-	ctx->mask = spdk_zmalloc(ctx->super->used_cluster_mask_len * sizeof(struct spdk_blob_md_page),
+	ctx->mask = spdk_aligned_zmalloc(ctx->super->used_cluster_mask_len * sizeof(struct spdk_blob_md_page),
 				 0x1000, NULL);
 	if (!ctx->mask) {
-		spdk_free(ctx->super);
+		spdk_aligned_free(ctx->super);
 		free(ctx);
 		spdk_bs_sequence_finish(seq, -ENOMEM);
 		return;
@@ -1620,10 +1620,10 @@ _spdk_bs_unload_read_super_cpl(spdk_bs_sequence_t *seq, void *cb_arg, int bserrn
 	uint64_t			lba, lba_count;
 
 	/* Write out the used page mask */
-	ctx->mask = spdk_zmalloc(ctx->super->used_page_mask_len * sizeof(struct spdk_blob_md_page),
+	ctx->mask = spdk_aligned_zmalloc(ctx->super->used_page_mask_len * sizeof(struct spdk_blob_md_page),
 				 0x1000, NULL);
 	if (!ctx->mask) {
-		spdk_free(ctx->super);
+		spdk_aligned_free(ctx->super);
 		free(ctx);
 		spdk_bs_sequence_finish(seq, -ENOMEM);
 		return;
@@ -1666,7 +1666,7 @@ spdk_bs_unload(struct spdk_blob_store *bs, spdk_bs_op_complete cb_fn, void *cb_a
 
 	ctx->bs = bs;
 
-	ctx->super = spdk_zmalloc(sizeof(*ctx->super), 0x1000, NULL);
+	ctx->super = spdk_aligned_zmalloc(sizeof(*ctx->super), 0x1000, NULL);
 	if (!ctx->super) {
 		free(ctx);
 		cb_fn(cb_arg, -ENOMEM);
@@ -1679,7 +1679,7 @@ spdk_bs_unload(struct spdk_blob_store *bs, spdk_bs_op_complete cb_fn, void *cb_a
 
 	seq = spdk_bs_sequence_start(bs->md_channel, &cpl);
 	if (!seq) {
-		spdk_free(ctx->super);
+		spdk_aligned_free(ctx->super);
 		free(ctx);
 		cb_fn(cb_arg, -ENOMEM);
 		return;

--- a/lib/blobfs/blobfs.c
+++ b/lib/blobfs/blobfs.c
@@ -1249,7 +1249,7 @@ __rw_done(void *ctx, int bserrno)
 	struct spdk_fs_request *req = ctx;
 	struct spdk_fs_cb_args *args = &req->args;
 
-	spdk_free(args->op.rw.pin_buf);
+	spdk_aligned_free(args->op.rw.pin_buf);
 	args->fn.file_op(args->arg, bserrno);
 	free_fs_request(req);
 }
@@ -1334,7 +1334,7 @@ __readwrite(struct spdk_file *file, struct spdk_io_channel *_channel,
 
 	__get_page_parameters(file, offset, length, &start_page, &page_size, &num_pages);
 	pin_buf_length = num_pages * page_size;
-	args->op.rw.pin_buf = spdk_malloc(pin_buf_length, 4096, NULL);
+	args->op.rw.pin_buf = spdk_aligned_malloc(pin_buf_length, 4096, NULL);
 
 	args->op.rw.start_page = start_page;
 	args->op.rw.num_pages = num_pages;

--- a/lib/copy/ioat/copy_engine_ioat.c
+++ b/lib/copy/ioat/copy_engine_ioat.c
@@ -130,7 +130,7 @@ copy_engine_ioat_exit(void)
 		TAILQ_REMOVE(&g_devices, dev, tailq);
 		spdk_ioat_detach(dev->ioat);
 		ioat_free_device(dev);
-		spdk_free(dev);
+		spdk_aligned_free(dev);
 	}
 	return;
 }
@@ -263,7 +263,7 @@ attach_cb(void *cb_ctx, struct spdk_pci_device *pci_dev, struct spdk_ioat_chan *
 {
 	struct ioat_device *dev;
 
-	dev = spdk_zmalloc(sizeof(*dev), 0, NULL);
+	dev = spdk_aligned_zmalloc(sizeof(*dev), 0, NULL);
 	if (dev == NULL) {
 		SPDK_ERRLOG("Failed to allocate device struct\n");
 		return;

--- a/lib/env_dpdk/env.c
+++ b/lib/env_dpdk/env.c
@@ -44,7 +44,7 @@
 #include <rte_version.h>
 
 void *
-spdk_malloc(size_t size, size_t align, uint64_t *phys_addr)
+spdk_aligned_malloc(size_t size, size_t align, uint64_t *phys_addr)
 {
 	void *buf = rte_malloc(NULL, size, align);
 	if (buf && phys_addr) {
@@ -54,9 +54,9 @@ spdk_malloc(size_t size, size_t align, uint64_t *phys_addr)
 }
 
 void *
-spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
+spdk_aligned_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
 {
-	void *buf = spdk_malloc(size, align, phys_addr);
+	void *buf = spdk_aligned_malloc(size, align, phys_addr);
 	if (buf) {
 		memset(buf, 0, size);
 	}
@@ -64,7 +64,7 @@ spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
 }
 
 void *
-spdk_realloc(void *buf, size_t size, size_t align, uint64_t *phys_addr)
+spdk_aligned_realloc(void *buf, size_t size, size_t align, uint64_t *phys_addr)
 {
 	void *new_buf = rte_realloc(buf, size, align);
 	if (new_buf && phys_addr) {
@@ -74,7 +74,7 @@ spdk_realloc(void *buf, size_t size, size_t align, uint64_t *phys_addr)
 }
 
 void
-spdk_free(void *buf)
+spdk_aligned_free(void *buf)
 {
 	rte_free(buf);
 }

--- a/lib/ioat/ioat.c
+++ b/lib/ioat/ioat.c
@@ -354,11 +354,11 @@ ioat_channel_destruct(struct spdk_ioat_chan *ioat)
 	}
 
 	if (ioat->hw_ring) {
-		spdk_free(ioat->hw_ring);
+		spdk_aligned_free(ioat->hw_ring);
 	}
 
 	if (ioat->comp_update) {
-		spdk_free((void *)ioat->comp_update);
+		spdk_aligned_free((void *)ioat->comp_update);
 		ioat->comp_update = NULL;
 	}
 
@@ -404,7 +404,7 @@ ioat_channel_start(struct spdk_ioat_chan *ioat)
 		ioat->max_xfer_size = 1U << xfercap;
 	}
 
-	ioat->comp_update = spdk_zmalloc(sizeof(*ioat->comp_update), SPDK_IOAT_CHANCMP_ALIGN,
+	ioat->comp_update = spdk_aligned_zmalloc(sizeof(*ioat->comp_update), SPDK_IOAT_CHANCMP_ALIGN,
 					 &comp_update_bus_addr);
 	if (ioat->comp_update == NULL) {
 		return -1;
@@ -419,7 +419,7 @@ ioat_channel_start(struct spdk_ioat_chan *ioat)
 		return -1;
 	}
 
-	ioat->hw_ring = spdk_zmalloc(num_descriptors * sizeof(union spdk_ioat_hw_desc), 64,
+	ioat->hw_ring = spdk_aligned_zmalloc(num_descriptors * sizeof(union spdk_ioat_hw_desc), 64,
 				     &ioat->hw_ring_phys_addr);
 	if (!ioat->hw_ring) {
 		return -1;

--- a/lib/iscsi/iscsi_subsystem.c
+++ b/lib/iscsi/iscsi_subsystem.c
@@ -599,7 +599,7 @@ spdk_iscsi_app_read_parameters(void)
 	g_spdk_iscsi.MaxSessions = MaxSessions;
 	SPDK_TRACELOG(SPDK_TRACE_DEBUG, "MaxSessions %d\n", g_spdk_iscsi.MaxSessions);
 
-	g_spdk_iscsi.session = spdk_zmalloc(sizeof(void *) * g_spdk_iscsi.MaxSessions, 0, NULL);
+	g_spdk_iscsi.session = spdk_aligned_zmalloc(sizeof(void *) * g_spdk_iscsi.MaxSessions, 0, NULL);
 	if (!g_spdk_iscsi.session) {
 		perror("Unable to allocate session pointer array\n");
 		return -1;

--- a/lib/nvme/nvme.c
+++ b/lib/nvme/nvme.c
@@ -139,7 +139,7 @@ nvme_user_copy_cmd_complete(void *arg, const struct spdk_nvme_cpl *cpl)
 			memcpy(req->user_buffer, req->payload.u.contig, req->payload_size);
 		}
 
-		spdk_free(req->payload.u.contig);
+		spdk_aligned_free(req->payload.u.contig);
 	}
 
 	/* Call the user's original callback now that the buffer has been copied */
@@ -162,7 +162,7 @@ nvme_allocate_request_user_copy(struct spdk_nvme_qpair *qpair,
 	uint64_t phys_addr;
 
 	if (buffer && payload_size) {
-		contig_buffer = spdk_zmalloc(payload_size, 4096, &phys_addr);
+		contig_buffer = spdk_aligned_zmalloc(payload_size, 4096, &phys_addr);
 		if (!contig_buffer) {
 			return NULL;
 		}
@@ -175,7 +175,7 @@ nvme_allocate_request_user_copy(struct spdk_nvme_qpair *qpair,
 	req = nvme_allocate_request_contig(qpair, contig_buffer, payload_size, nvme_user_copy_cmd_complete,
 					   NULL);
 	if (!req) {
-		spdk_free(contig_buffer);
+		spdk_aligned_free(contig_buffer);
 		return NULL;
 	}
 

--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -224,7 +224,7 @@ spdk_nvme_ctrlr_free_io_qpair(struct spdk_nvme_qpair *qpair)
 	TAILQ_REMOVE(&ctrlr->active_io_qpairs, qpair, tailq);
 	spdk_bit_array_set(ctrlr->free_io_qids, qpair->id);
 
-	spdk_free(qpair->req_buf);
+	spdk_aligned_free(qpair->req_buf);
 
 	if (nvme_transport_ctrlr_delete_io_qpair(ctrlr, qpair)) {
 		nvme_robust_mutex_unlock(&ctrlr->ctrlr_lock);
@@ -274,7 +274,7 @@ static int nvme_ctrlr_set_intel_support_log_pages(struct spdk_nvme_ctrlr *ctrlr)
 	struct nvme_completion_poll_status	status;
 	struct spdk_nvme_intel_log_page_directory *log_page_directory;
 
-	log_page_directory = spdk_zmalloc(sizeof(struct spdk_nvme_intel_log_page_directory),
+	log_page_directory = spdk_aligned_zmalloc(sizeof(struct spdk_nvme_intel_log_page_directory),
 					  64, &phys_addr);
 	if (log_page_directory == NULL) {
 		SPDK_ERRLOG("could not allocate log_page_directory\n");
@@ -290,13 +290,13 @@ static int nvme_ctrlr_set_intel_support_log_pages(struct spdk_nvme_ctrlr *ctrlr)
 		spdk_nvme_qpair_process_completions(ctrlr->adminq, 0);
 	}
 	if (spdk_nvme_cpl_is_error(&status.cpl)) {
-		spdk_free(log_page_directory);
+		spdk_aligned_free(log_page_directory);
 		SPDK_ERRLOG("nvme_ctrlr_cmd_get_log_page failed!\n");
 		return -ENXIO;
 	}
 
 	nvme_ctrlr_construct_intel_support_log_page_list(ctrlr, log_page_directory);
-	spdk_free(log_page_directory);
+	spdk_aligned_free(log_page_directory);
 	return 0;
 }
 
@@ -739,13 +739,13 @@ nvme_ctrlr_destruct_namespaces(struct spdk_nvme_ctrlr *ctrlr)
 			nvme_ns_destruct(&ctrlr->ns[i]);
 		}
 
-		spdk_free(ctrlr->ns);
+		spdk_aligned_free(ctrlr->ns);
 		ctrlr->ns = NULL;
 		ctrlr->num_ns = 0;
 	}
 
 	if (ctrlr->nsdata) {
-		spdk_free(ctrlr->nsdata);
+		spdk_aligned_free(ctrlr->nsdata);
 		ctrlr->nsdata = NULL;
 	}
 }
@@ -767,13 +767,13 @@ nvme_ctrlr_construct_namespaces(struct spdk_nvme_ctrlr *ctrlr)
 	if (nn != ctrlr->num_ns) {
 		nvme_ctrlr_destruct_namespaces(ctrlr);
 
-		ctrlr->ns = spdk_zmalloc(nn * sizeof(struct spdk_nvme_ns), 64,
+		ctrlr->ns = spdk_aligned_zmalloc(nn * sizeof(struct spdk_nvme_ns), 64,
 					 &phys_addr);
 		if (ctrlr->ns == NULL) {
 			goto fail;
 		}
 
-		ctrlr->nsdata = spdk_zmalloc(nn * sizeof(struct spdk_nvme_ns_data), 64,
+		ctrlr->nsdata = spdk_aligned_zmalloc(nn * sizeof(struct spdk_nvme_ns_data), 64,
 					     &phys_addr);
 		if (ctrlr->nsdata == NULL) {
 			goto fail;
@@ -908,7 +908,7 @@ nvme_ctrlr_add_process(struct spdk_nvme_ctrlr *ctrlr, void *devhandle)
 	}
 
 	/* Initialize the per process properties for this ctrlr */
-	ctrlr_proc = spdk_zmalloc(sizeof(struct spdk_nvme_ctrlr_process), 64, NULL);
+	ctrlr_proc = spdk_aligned_zmalloc(sizeof(struct spdk_nvme_ctrlr_process), 64, NULL);
 	if (ctrlr_proc == NULL) {
 		SPDK_ERRLOG("failed to allocate memory to track the process props\n");
 
@@ -945,7 +945,7 @@ nvme_ctrlr_remove_process(struct spdk_nvme_ctrlr *ctrlr,
 
 	TAILQ_REMOVE(&ctrlr->active_procs, proc, tailq);
 
-	spdk_free(proc);
+	spdk_aligned_free(proc);
 }
 
 /**
@@ -980,7 +980,7 @@ nvme_ctrlr_cleanup_process(struct spdk_nvme_ctrlr_process *proc)
 		spdk_nvme_ctrlr_free_io_qpair(qpair);
 	}
 
-	spdk_free(proc);
+	spdk_aligned_free(proc);
 }
 
 /**
@@ -999,7 +999,7 @@ nvme_ctrlr_free_processes(struct spdk_nvme_ctrlr *ctrlr)
 
 		assert(STAILQ_EMPTY(&active_proc->active_reqs));
 
-		spdk_free(active_proc);
+		spdk_aligned_free(active_proc);
 	}
 }
 

--- a/lib/nvme/nvme_pcie.c
+++ b/lib/nvme/nvme_pcie.c
@@ -562,7 +562,7 @@ nvme_pcie_ctrlr_construct_admin_qpair(struct spdk_nvme_ctrlr *ctrlr)
 	struct nvme_pcie_qpair *pqpair;
 	int rc;
 
-	pqpair = spdk_zmalloc(sizeof(*pqpair), 64, NULL);
+	pqpair = spdk_aligned_zmalloc(sizeof(*pqpair), 64, NULL);
 	if (pqpair == NULL) {
 		return -ENOMEM;
 	}
@@ -678,7 +678,7 @@ struct spdk_nvme_ctrlr *nvme_pcie_ctrlr_construct(const struct spdk_nvme_transpo
 	int rc;
 	struct spdk_pci_id pci_id;
 
-	pctrlr = spdk_zmalloc(sizeof(struct nvme_pcie_ctrlr), 64, NULL);
+	pctrlr = spdk_aligned_zmalloc(sizeof(struct nvme_pcie_ctrlr), 64, NULL);
 	if (pctrlr == NULL) {
 		SPDK_ERRLOG("could not allocate ctrlr\n");
 		return NULL;
@@ -693,7 +693,7 @@ struct spdk_nvme_ctrlr *nvme_pcie_ctrlr_construct(const struct spdk_nvme_transpo
 
 	rc = nvme_pcie_ctrlr_allocate_bars(pctrlr);
 	if (rc != 0) {
-		spdk_free(pctrlr);
+		spdk_aligned_free(pctrlr);
 		return NULL;
 	}
 
@@ -704,7 +704,7 @@ struct spdk_nvme_ctrlr *nvme_pcie_ctrlr_construct(const struct spdk_nvme_transpo
 
 	if (nvme_ctrlr_get_cap(&pctrlr->ctrlr, &cap)) {
 		SPDK_ERRLOG("get_cap() failed\n");
-		spdk_free(pctrlr);
+		spdk_aligned_free(pctrlr);
 		return NULL;
 	}
 
@@ -787,7 +787,7 @@ nvme_pcie_ctrlr_destruct(struct spdk_nvme_ctrlr *ctrlr)
 
 	nvme_pcie_ctrlr_free_bars(pctrlr);
 	spdk_pci_device_detach(pctrlr->devhandle);
-	spdk_free(pctrlr);
+	spdk_aligned_free(pctrlr);
 
 	return 0;
 }
@@ -862,7 +862,7 @@ nvme_pcie_qpair_construct(struct spdk_nvme_qpair *qpair)
 		}
 	}
 	if (pqpair->sq_in_cmb == false) {
-		pqpair->cmd = spdk_zmalloc(pqpair->num_entries * sizeof(struct spdk_nvme_cmd),
+		pqpair->cmd = spdk_aligned_zmalloc(pqpair->num_entries * sizeof(struct spdk_nvme_cmd),
 					   0x1000,
 					   &pqpair->cmd_bus_addr);
 		if (pqpair->cmd == NULL) {
@@ -871,7 +871,7 @@ nvme_pcie_qpair_construct(struct spdk_nvme_qpair *qpair)
 		}
 	}
 
-	pqpair->cpl = spdk_zmalloc(pqpair->num_entries * sizeof(struct spdk_nvme_cpl),
+	pqpair->cpl = spdk_aligned_zmalloc(pqpair->num_entries * sizeof(struct spdk_nvme_cpl),
 				   0x1000,
 				   &pqpair->cpl_bus_addr);
 	if (pqpair->cpl == NULL) {
@@ -889,7 +889,7 @@ nvme_pcie_qpair_construct(struct spdk_nvme_qpair *qpair)
 	 *   This ensures the PRP list embedded in the nvme_tracker object will not span a
 	 *   4KB boundary, while allowing access to trackers in tr[] via normal array indexing.
 	 */
-	pqpair->tr = spdk_zmalloc(num_trackers * sizeof(*tr), sizeof(*tr), &phys_addr);
+	pqpair->tr = spdk_aligned_zmalloc(num_trackers * sizeof(*tr), sizeof(*tr), &phys_addr);
 	if (pqpair->tr == NULL) {
 		SPDK_ERRLOG("nvme_tr failed\n");
 		return -ENOMEM;
@@ -1173,16 +1173,16 @@ nvme_pcie_qpair_destroy(struct spdk_nvme_qpair *qpair)
 		nvme_pcie_admin_qpair_destroy(qpair);
 	}
 	if (pqpair->cmd && !pqpair->sq_in_cmb) {
-		spdk_free(pqpair->cmd);
+		spdk_aligned_free(pqpair->cmd);
 	}
 	if (pqpair->cpl) {
-		spdk_free(pqpair->cpl);
+		spdk_aligned_free(pqpair->cpl);
 	}
 	if (pqpair->tr) {
-		spdk_free(pqpair->tr);
+		spdk_aligned_free(pqpair->tr);
 	}
 
-	spdk_free(pqpair);
+	spdk_aligned_free(pqpair);
 
 	return 0;
 }
@@ -1413,7 +1413,7 @@ nvme_pcie_ctrlr_create_io_qpair(struct spdk_nvme_ctrlr *ctrlr, uint16_t qid,
 
 	assert(ctrlr != NULL);
 
-	pqpair = spdk_zmalloc(sizeof(*pqpair), 64, NULL);
+	pqpair = spdk_aligned_zmalloc(sizeof(*pqpair), 64, NULL);
 	if (pqpair == NULL) {
 		return NULL;
 	}

--- a/lib/nvme/nvme_qpair.c
+++ b/lib/nvme/nvme_qpair.c
@@ -381,7 +381,7 @@ nvme_qpair_init(struct spdk_nvme_qpair *qpair, uint16_t id,
 
 	req_size_padded = (sizeof(struct nvme_request) + 63) & ~(size_t)63;
 
-	qpair->req_buf = spdk_zmalloc(req_size_padded * num_requests, 64, NULL);
+	qpair->req_buf = spdk_aligned_zmalloc(req_size_padded * num_requests, 64, NULL);
 	if (qpair->req_buf == NULL) {
 		return -ENOMEM;
 	}

--- a/lib/nvme/nvme_rdma.c
+++ b/lib/nvme/nvme_rdma.c
@@ -580,7 +580,7 @@ nvme_rdma_qpair_fabric_connect(struct nvme_rdma_qpair *rqpair)
 
 	rctrlr = nvme_rdma_ctrlr(ctrlr);
 
-	nvmf_data = spdk_zmalloc(sizeof(*nvmf_data), 0, NULL);
+	nvmf_data = spdk_aligned_zmalloc(sizeof(*nvmf_data), 0, NULL);
 	if (!nvmf_data) {
 		SPDK_ERRLOG("nvmf_data allocation error\n");
 		rc = -1;
@@ -629,7 +629,7 @@ nvme_rdma_qpair_fabric_connect(struct nvme_rdma_qpair *rqpair)
 	rsp = (struct spdk_nvmf_fabric_connect_rsp *)&status.cpl;
 	rctrlr->cntlid = rsp->status_code_specific.success.cntlid;
 ret:
-	spdk_free(nvmf_data);
+	spdk_aligned_free(nvmf_data);
 	return rc;
 }
 

--- a/lib/nvmf/rdma.c
+++ b/lib/nvmf/rdma.c
@@ -253,9 +253,9 @@ spdk_nvmf_rdma_conn_destroy(struct spdk_nvmf_rdma_conn *rdma_conn)
 	}
 
 	/* Free all memory */
-	spdk_free(rdma_conn->cmds);
-	spdk_free(rdma_conn->cpls);
-	spdk_free(rdma_conn->bufs);
+	spdk_aligned_free(rdma_conn->cmds);
+	spdk_aligned_free(rdma_conn->cpls);
+	spdk_aligned_free(rdma_conn->bufs);
 	free(rdma_conn->reqs);
 	free(rdma_conn);
 }
@@ -321,11 +321,11 @@ spdk_nvmf_rdma_conn_create(struct rdma_cm_id *id, struct ibv_comp_channel *chann
 
 	rdma_conn->reqs = calloc(max_queue_depth, sizeof(*rdma_conn->reqs));
 	rdma_conn->recvs = calloc(max_queue_depth, sizeof(*rdma_conn->recvs));
-	rdma_conn->cmds = spdk_zmalloc(max_queue_depth * sizeof(*rdma_conn->cmds),
+	rdma_conn->cmds = spdk_aligned_zmalloc(max_queue_depth * sizeof(*rdma_conn->cmds),
 				       0x1000, NULL);
-	rdma_conn->cpls = spdk_zmalloc(max_queue_depth * sizeof(*rdma_conn->cpls),
+	rdma_conn->cpls = spdk_aligned_zmalloc(max_queue_depth * sizeof(*rdma_conn->cpls),
 				       0x1000, NULL);
-	rdma_conn->bufs = spdk_zmalloc(max_queue_depth * g_rdma.in_capsule_data_size,
+	rdma_conn->bufs = spdk_aligned_zmalloc(max_queue_depth * g_rdma.in_capsule_data_size,
 				       0x1000, NULL);
 	if (!rdma_conn->reqs || !rdma_conn->recvs || !rdma_conn->cmds ||
 	    !rdma_conn->cpls || !rdma_conn->bufs) {
@@ -1226,7 +1226,7 @@ spdk_nvmf_rdma_session_init(void)
 	/* TODO: Make the number of elements in this pool configurable. For now, one full queue
 	 *       worth seems reasonable.
 	 */
-	rdma_sess->buf = spdk_zmalloc(g_rdma.max_queue_depth * g_rdma.max_io_size,
+	rdma_sess->buf = spdk_aligned_zmalloc(g_rdma.max_queue_depth * g_rdma.max_io_size,
 				      0x20000, NULL);
 	if (!rdma_sess->buf) {
 		SPDK_ERRLOG("Large buffer pool allocation failed (%d x %d)\n",
@@ -1256,7 +1256,7 @@ spdk_nvmf_rdma_session_fini(struct spdk_nvmf_session *session)
 	}
 
 	ibv_dereg_mr(rdma_sess->buf_mr);
-	spdk_free(rdma_sess->buf);
+	spdk_aligned_free(rdma_sess->buf);
 	free(rdma_sess);
 }
 
@@ -1285,7 +1285,7 @@ spdk_nvmf_rdma_session_add_conn(struct spdk_nvmf_session *session,
 	if (!rdma_sess->buf_mr) {
 		SPDK_ERRLOG("Large buffer pool registration failed (%d x %d)\n",
 			    g_rdma.max_queue_depth, g_rdma.max_io_size);
-		spdk_free(rdma_sess->buf);
+		spdk_aligned_free(rdma_sess->buf);
 		free(rdma_sess);
 		return -1;
 	}

--- a/lib/scsi/scsi_bdev.c
+++ b/lib/scsi/scsi_bdev.c
@@ -1528,7 +1528,7 @@ spdk_bdev_scsi_unmap(struct spdk_bdev *bdev,
 	} else {
 		desc = spdk_scsi_task_alloc_data(task, bdesc_data_len - 8);
 		memcpy(desc, &data[8], bdesc_data_len - 8);
-		spdk_free(data);
+		spdk_aligned_free(data);
 	}
 
 	if (bdesc_count > bdev->max_unmap_bdesc_count) {
@@ -1718,7 +1718,7 @@ spdk_bdev_scsi_process_primary(struct spdk_bdev *bdev,
 	case SPDK_SPC_INQUIRY:
 		alloc_len = from_be16(&cdb[3]);
 		data_len = SPDK_MAX(4096, alloc_len);
-		data = spdk_zmalloc(data_len, 0, NULL);
+		data = spdk_aligned_zmalloc(data_len, 0, NULL);
 		assert(data != NULL);
 		rc = spdk_bdev_scsi_inquiry(bdev, task, cdb, data, data_len);
 		data_len = SPDK_MIN(rc, data_len);
@@ -1742,7 +1742,7 @@ spdk_bdev_scsi_process_primary(struct spdk_bdev *bdev,
 		}
 
 		data_len = SPDK_MAX(4096, alloc_len);
-		data = spdk_zmalloc(data_len, 0, NULL);
+		data = spdk_aligned_zmalloc(data_len, 0, NULL);
 		assert(data != NULL);
 		rc = spdk_bdev_scsi_report_luns(task->lun, sel, data, data_len);
 		data_len = rc;
@@ -1850,7 +1850,7 @@ spdk_bdev_scsi_process_primary(struct spdk_bdev *bdev,
 		}
 
 		data_len = rc;
-		data = spdk_zmalloc(data_len, 0, NULL);
+		data = spdk_aligned_zmalloc(data_len, 0, NULL);
 		assert(data != NULL);
 
 		/* First call with no buffer to discover needed buffer size */
@@ -1892,7 +1892,7 @@ spdk_bdev_scsi_process_primary(struct spdk_bdev *bdev,
 		spdk_scsi_task_build_sense_data(task, sk, asc, ascq);
 
 		data_len = task->sense_data_len;
-		data = spdk_zmalloc(data_len, 0, NULL);
+		data = spdk_aligned_zmalloc(data_len, 0, NULL);
 		assert(data != NULL);
 		memcpy(data, task->sense_data, data_len);
 		break;
@@ -1941,7 +1941,7 @@ spdk_bdev_scsi_process_primary(struct spdk_bdev *bdev,
 	}
 
 	if (data)
-		spdk_free(data);
+		spdk_aligned_free(data);
 
 	return SPDK_SCSI_TASK_COMPLETE;
 }

--- a/lib/scsi/task.c
+++ b/lib/scsi/task.c
@@ -109,7 +109,7 @@ void
 spdk_scsi_task_free_data(struct spdk_scsi_task *task)
 {
 	if (task->alloc_len != 0) {
-		spdk_free(task->iov.iov_base);
+		spdk_aligned_free(task->iov.iov_base);
 		task->alloc_len = 0;
 	}
 
@@ -122,7 +122,7 @@ spdk_scsi_task_alloc_data(struct spdk_scsi_task *task, uint32_t alloc_len)
 {
 	assert(task->alloc_len == 0);
 
-	task->iov.iov_base = spdk_zmalloc(alloc_len, 0, NULL);
+	task->iov.iov_base = spdk_aligned_zmalloc(alloc_len, 0, NULL);
 	task->iov.iov_len = alloc_len;
 	task->alloc_len = alloc_len;
 
@@ -189,7 +189,7 @@ spdk_scsi_task_gather_data(struct spdk_scsi_task *task, int *len)
 		return NULL;
 	}
 
-	buf = spdk_malloc(buf_len, 0, NULL);
+	buf = spdk_aligned_malloc(buf_len, 0, NULL);
 	if (buf == NULL) {
 		*len = -1;
 		return NULL;

--- a/lib/util/bit_array.c
+++ b/lib/util/bit_array.c
@@ -79,7 +79,7 @@ spdk_bit_array_free(struct spdk_bit_array **bap)
 
 	ba = *bap;
 	*bap = NULL;
-	spdk_free(ba);
+	spdk_aligned_free(ba);
 }
 
 static inline uint32_t
@@ -115,7 +115,7 @@ spdk_bit_array_resize(struct spdk_bit_array **bap, uint32_t num_bits)
 	 */
 	new_size += SPDK_BIT_ARRAY_WORD_BYTES;
 
-	new_ba = (struct spdk_bit_array *)spdk_realloc(*bap, new_size, 64, NULL);
+	new_ba = (struct spdk_bit_array *)spdk_aligned_realloc(*bap, new_size, 64, NULL);
 	if (!new_ba) {
 		return -ENOMEM;
 	}

--- a/test/lib/bdev/bdevio/bdevio.c
+++ b/test/lib/bdev/bdevio/bdevio.c
@@ -166,7 +166,7 @@ static enum spdk_bdev_io_status g_completion_status;
 static void
 initialize_buffer(char **buf, int pattern, int size)
 {
-	*buf = spdk_zmalloc(size, 0x1000, NULL);
+	*buf = spdk_aligned_zmalloc(size, 0x1000, NULL);
 	memset(*buf, pattern, size);
 }
 
@@ -285,8 +285,8 @@ blockdev_write_read_data_match(char *rx_buf, char *tx_buf, int data_length)
 	int rc;
 	rc = memcmp(rx_buf, tx_buf, data_length);
 
-	spdk_free(rx_buf);
-	spdk_free(tx_buf);
+	spdk_aligned_free(rx_buf);
+	spdk_aligned_free(tx_buf);
 
 	return rc;
 }

--- a/test/lib/bdev/bdevperf/bdevperf.c
+++ b/test/lib/bdev/bdevperf/bdevperf.c
@@ -281,7 +281,7 @@ task_ctor(struct rte_mempool *mp, void *arg, void *__task, unsigned id)
 {
 	struct bdevperf_task *task = __task;
 
-	task->buf = spdk_zmalloc(g_io_size, g_min_alignment, NULL);
+	task->buf = spdk_aligned_zmalloc(g_io_size, g_min_alignment, NULL);
 }
 
 static __thread unsigned int seed = 0;

--- a/test/lib/env/vtophys/vtophys.c
+++ b/test/lib/env/vtophys/vtophys.c
@@ -86,18 +86,18 @@ vtophys_positive_test(void)
 	int rc = 0;
 
 	for (i = 0; i < 31; i++) {
-		p = spdk_zmalloc(size, 512, NULL);
+		p = spdk_aligned_zmalloc(size, 512, NULL);
 		if (p == NULL)
 			continue;
 
 		if (spdk_vtophys(p) == SPDK_VTOPHYS_ERROR) {
 			rc = -1;
 			printf("Err: VA=%p is not mapped to a huge_page,\n", p);
-			spdk_free(p);
+			spdk_aligned_free(p);
 			break;
 		}
 
-		spdk_free(p);
+		spdk_aligned_free(p);
 		size = size << 1;
 	}
 

--- a/test/lib/ioat/unit/ioat_ut.c
+++ b/test/lib/ioat/unit/ioat_ut.c
@@ -40,12 +40,12 @@
 #include "ioat/ioat.c"
 
 void *
-spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
+spdk_aligned_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
 {
 	return calloc(1, size);
 }
 
-void spdk_free(void *buf)
+void spdk_aligned_free(void *buf)
 {
 	free(buf);
 }

--- a/test/lib/nvme/aer/aer.c
+++ b/test/lib/nvme/aer/aer.c
@@ -160,7 +160,7 @@ cleanup(void)
 
 	foreach_dev(dev) {
 		if (dev->health_page) {
-			spdk_free(dev->health_page);
+			spdk_aligned_free(dev->health_page);
 		}
 	}
 }
@@ -275,7 +275,7 @@ attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid,
 
 	printf("Attached to %s\n", dev->name);
 
-	dev->health_page = spdk_zmalloc(sizeof(*dev->health_page), 4096, NULL);
+	dev->health_page = spdk_aligned_zmalloc(sizeof(*dev->health_page), 4096, NULL);
 	if (dev->health_page == NULL) {
 		printf("Allocation error (health page)\n");
 		failed = 1;

--- a/test/lib/nvme/e2edp/nvme_dp.c
+++ b/test/lib/nvme/e2edp/nvme_dp.c
@@ -178,7 +178,7 @@ static uint32_t dp_guard_check_extended_lba_test(struct spdk_nvme_ns *ns, struct
 
 	sector_size = spdk_nvme_ns_get_sector_size(ns);
 	md_size = spdk_nvme_ns_get_md_size(ns);
-	req->contig = spdk_zmalloc((sector_size + md_size) * req->lba_count, 0x1000, NULL);
+	req->contig = spdk_aligned_zmalloc((sector_size + md_size) * req->lba_count, 0x1000, NULL);
 	if (!req->contig)
 		return 0;
 
@@ -214,7 +214,7 @@ static uint32_t dp_with_pract_test(struct spdk_nvme_ns *ns, struct io_request *r
 
 	sector_size = spdk_nvme_ns_get_sector_size(ns);
 	/* No additional metadata buffer provided */
-	req->contig = spdk_zmalloc(sector_size * req->lba_count, 0x1000, NULL);
+	req->contig = spdk_aligned_zmalloc(sector_size * req->lba_count, 0x1000, NULL);
 	if (!req->contig)
 		return 0;
 
@@ -261,7 +261,7 @@ static uint32_t dp_without_pract_extended_lba_test(struct spdk_nvme_ns *ns, stru
 
 	sector_size = spdk_nvme_ns_get_sector_size(ns);
 	md_size = spdk_nvme_ns_get_md_size(ns);
-	req->contig = spdk_zmalloc((sector_size + md_size) * req->lba_count, 0x1000, NULL);
+	req->contig = spdk_aligned_zmalloc((sector_size + md_size) * req->lba_count, 0x1000, NULL);
 	if (!req->contig)
 		return 0;
 
@@ -295,7 +295,7 @@ static uint32_t dp_without_flags_extended_lba_test(struct spdk_nvme_ns *ns, stru
 
 	sector_size = spdk_nvme_ns_get_sector_size(ns);
 	md_size = spdk_nvme_ns_get_md_size(ns);
-	req->contig = spdk_zmalloc((sector_size + md_size) * req->lba_count, 0x1000, NULL);
+	req->contig = spdk_aligned_zmalloc((sector_size + md_size) * req->lba_count, 0x1000, NULL);
 	if (!req->contig)
 		return 0;
 
@@ -329,13 +329,13 @@ static uint32_t dp_without_pract_separate_meta_test(struct spdk_nvme_ns *ns, str
 
 	sector_size = spdk_nvme_ns_get_sector_size(ns);
 	md_size = spdk_nvme_ns_get_md_size(ns);
-	req->contig = spdk_zmalloc(sector_size * req->lba_count, 0x1000, NULL);
+	req->contig = spdk_aligned_zmalloc(sector_size * req->lba_count, 0x1000, NULL);
 	if (!req->contig)
 		return 0;
 
-	req->metadata = spdk_zmalloc(md_size * req->lba_count, 0x1000, NULL);
+	req->metadata = spdk_aligned_zmalloc(md_size * req->lba_count, 0x1000, NULL);
 	if (!req->metadata) {
-		spdk_free(req->contig);
+		spdk_aligned_free(req->contig);
 		return 0;
 	}
 
@@ -372,13 +372,13 @@ static uint32_t dp_without_pract_separate_meta_apptag_test(struct spdk_nvme_ns *
 
 	sector_size = spdk_nvme_ns_get_sector_size(ns);
 	md_size = spdk_nvme_ns_get_md_size(ns);
-	req->contig = spdk_zmalloc(sector_size * req->lba_count, 0x1000, NULL);
+	req->contig = spdk_aligned_zmalloc(sector_size * req->lba_count, 0x1000, NULL);
 	if (!req->contig)
 		return 0;
 
-	req->metadata = spdk_zmalloc(md_size * req->lba_count, 0x1000, NULL);
+	req->metadata = spdk_aligned_zmalloc(md_size * req->lba_count, 0x1000, NULL);
 	if (!req->metadata) {
-		spdk_free(req->contig);
+		spdk_aligned_free(req->contig);
 		return 0;
 	}
 
@@ -413,13 +413,13 @@ static uint32_t dp_without_flags_separate_meta_test(struct spdk_nvme_ns *ns, str
 
 	sector_size = spdk_nvme_ns_get_sector_size(ns);
 	md_size = spdk_nvme_ns_get_md_size(ns);
-	req->contig = spdk_zmalloc(sector_size * req->lba_count, 0x1000, NULL);
+	req->contig = spdk_aligned_zmalloc(sector_size * req->lba_count, 0x1000, NULL);
 	if (!req->contig)
 		return 0;
 
-	req->metadata = spdk_zmalloc(md_size * req->lba_count, 0x1000, NULL);
+	req->metadata = spdk_aligned_zmalloc(md_size * req->lba_count, 0x1000, NULL);
 	if (!req->metadata) {
-		spdk_free(req->contig);
+		spdk_aligned_free(req->contig);
 		return 0;
 	}
 
@@ -441,12 +441,12 @@ free_req(struct io_request *req)
 	}
 
 	if (req->contig)
-		spdk_free(req->contig);
+		spdk_aligned_free(req->contig);
 
 	if (req->metadata)
-		spdk_free(req->metadata);
+		spdk_aligned_free(req->metadata);
 
-	spdk_free(req);
+	spdk_aligned_free(req);
 }
 
 static int
@@ -503,7 +503,7 @@ write_read_e2e_dp_tests(struct dev *dev, nvme_build_io_req_fn_t build_io_fn, con
 		return 0;
 	}
 
-	req = spdk_zmalloc(sizeof(*req), 0, NULL);
+	req = spdk_aligned_zmalloc(sizeof(*req), 0, NULL);
 	if (!req) {
 		fprintf(stderr, "Allocate request failed\n");
 		return 0;

--- a/test/lib/nvme/overhead/overhead.c
+++ b/test/lib/nvme/overhead/overhead.c
@@ -582,15 +582,15 @@ int main(int argc, char **argv)
 		return rc;
 	}
 
-	g_task = spdk_zmalloc(sizeof(struct perf_task), 0, NULL);
+	g_task = spdk_aligned_zmalloc(sizeof(struct perf_task), 0, NULL);
 	if (g_task == NULL) {
 		fprintf(stderr, "g_task alloc failed\n");
 		exit(1);
 	}
 
-	g_task->buf = spdk_zmalloc(g_io_size_bytes, 0x1000, NULL);
+	g_task->buf = spdk_aligned_zmalloc(g_io_size_bytes, 0x1000, NULL);
 	if (g_task->buf == NULL) {
-		fprintf(stderr, "g_task->buf spdk_zmalloc failed\n");
+		fprintf(stderr, "g_task->buf spdk_aligned_zmalloc failed\n");
 		exit(1);
 	}
 

--- a/test/lib/nvme/reset/reset.c
+++ b/test/lib/nvme/reset/reset.c
@@ -159,9 +159,9 @@ static void task_ctor(struct rte_mempool *mp, void *arg, void *__task, unsigned 
 {
 	struct reset_task *task = __task;
 
-	task->buf = spdk_zmalloc(g_io_size_bytes, 0x200, NULL);
+	task->buf = spdk_aligned_zmalloc(g_io_size_bytes, 0x200, NULL);
 	if (task->buf == NULL) {
-		fprintf(stderr, "task->buf spdk_zmalloc failed\n");
+		fprintf(stderr, "task->buf spdk_aligned_zmalloc failed\n");
 		exit(1);
 	}
 }

--- a/test/lib/nvme/sgl/sgl.c
+++ b/test/lib/nvme/sgl/sgl.c
@@ -134,7 +134,7 @@ static void build_io_request_0(struct io_request *req)
 {
 	req->nseg = 1;
 
-	req->iovs[0].base = spdk_zmalloc(0x800, 4, NULL);
+	req->iovs[0].base = spdk_aligned_zmalloc(0x800, 4, NULL);
 	req->iovs[0].len = 0x800;
 }
 
@@ -143,7 +143,7 @@ static void build_io_request_1(struct io_request *req)
 	req->nseg = 1;
 
 	/* 512B for 1st sge */
-	req->iovs[0].base = spdk_zmalloc(0x200, 0x200, NULL);
+	req->iovs[0].base = spdk_aligned_zmalloc(0x200, 0x200, NULL);
 	req->iovs[0].len = 0x200;
 }
 
@@ -152,7 +152,7 @@ static void build_io_request_2(struct io_request *req)
 	req->nseg = 1;
 
 	/* 256KB for 1st sge */
-	req->iovs[0].base = spdk_zmalloc(0x40000, 0x1000, NULL);
+	req->iovs[0].base = spdk_aligned_zmalloc(0x40000, 0x1000, NULL);
 	req->iovs[0].len = 0x40000;
 }
 
@@ -162,16 +162,16 @@ static void build_io_request_3(struct io_request *req)
 
 	/* 2KB for 1st sge, make sure the iov address start at 0x800 boundary,
 	 *  and end with 0x1000 boundary */
-	req->iovs[0].base = spdk_zmalloc(0x1000, 0x1000, NULL);
+	req->iovs[0].base = spdk_aligned_zmalloc(0x1000, 0x1000, NULL);
 	req->iovs[0].offset = 0x800;
 	req->iovs[0].len = 0x800;
 
 	/* 4KB for 2th sge */
-	req->iovs[1].base = spdk_zmalloc(0x1000, 0x1000, NULL);
+	req->iovs[1].base = spdk_aligned_zmalloc(0x1000, 0x1000, NULL);
 	req->iovs[1].len = 0x1000;
 
 	/* 12KB for 3th sge */
-	req->iovs[2].base = spdk_zmalloc(0x3000, 0x1000, NULL);
+	req->iovs[2].base = spdk_aligned_zmalloc(0x3000, 0x1000, NULL);
 	req->iovs[2].len = 0x3000;
 }
 
@@ -182,12 +182,12 @@ static void build_io_request_4(struct io_request *req)
 	req->nseg = 32;
 
 	/* 4KB for 1st sge */
-	req->iovs[0].base = spdk_zmalloc(0x1000, 0x1000, NULL);
+	req->iovs[0].base = spdk_aligned_zmalloc(0x1000, 0x1000, NULL);
 	req->iovs[0].len = 0x1000;
 
 	/* 8KB for the rest 31 sge */
 	for (i = 1; i < req->nseg; i++) {
-		req->iovs[i].base = spdk_zmalloc(0x2000, 0x1000, NULL);
+		req->iovs[i].base = spdk_aligned_zmalloc(0x2000, 0x1000, NULL);
 		req->iovs[i].len = 0x2000;
 	}
 }
@@ -197,7 +197,7 @@ static void build_io_request_5(struct io_request *req)
 	req->nseg = 1;
 
 	/* 8KB for 1st sge */
-	req->iovs[0].base = spdk_zmalloc(0x2000, 0x1000, NULL);
+	req->iovs[0].base = spdk_aligned_zmalloc(0x2000, 0x1000, NULL);
 	req->iovs[0].len = 0x2000;
 }
 
@@ -206,11 +206,11 @@ static void build_io_request_6(struct io_request *req)
 	req->nseg = 2;
 
 	/* 4KB for 1st sge */
-	req->iovs[0].base = spdk_zmalloc(0x1000, 0x1000, NULL);
+	req->iovs[0].base = spdk_aligned_zmalloc(0x1000, 0x1000, NULL);
 	req->iovs[0].len = 0x1000;
 
 	/* 4KB for 2st sge */
-	req->iovs[1].base = spdk_zmalloc(0x1000, 0x1000, NULL);
+	req->iovs[1].base = spdk_aligned_zmalloc(0x1000, 0x1000, NULL);
 	req->iovs[1].len = 0x1000;
 }
 
@@ -224,7 +224,7 @@ static void build_io_request_7(struct io_request *req)
 	 * Create a 64KB sge, but ensure it is *not* aligned on a 4KB
 	 *  boundary.  This is valid for single element buffers with PRP.
 	 */
-	base = spdk_zmalloc(0x11000, 0x1000, NULL);
+	base = spdk_aligned_zmalloc(0x11000, 0x1000, NULL);
 	req->misalign = 64;
 	req->iovs[0].base = base + req->misalign;
 	req->iovs[0].len = 0x10000;
@@ -238,7 +238,7 @@ static void build_io_request_8(struct io_request *req)
 	 * 1KB for 1st sge, make sure the iov address does not start and end
 	 * at 0x1000 boundary
 	 */
-	req->iovs[0].base = spdk_zmalloc(0x1000, 0x1000, NULL);
+	req->iovs[0].base = spdk_aligned_zmalloc(0x1000, 0x1000, NULL);
 	req->iovs[0].offset = 0x400;
 	req->iovs[0].len = 0x400;
 
@@ -246,7 +246,7 @@ static void build_io_request_8(struct io_request *req)
 	 * 1KB for 1st sge, make sure the iov address does not start and end
 	 * at 0x1000 boundary
 	 */
-	req->iovs[1].base = spdk_zmalloc(0x1000, 0x1000, NULL);
+	req->iovs[1].base = spdk_aligned_zmalloc(0x1000, 0x1000, NULL);
 	req->iovs[1].offset = 0x400;
 	req->iovs[1].len = 0x400;
 }
@@ -266,7 +266,7 @@ static void build_io_request_9(struct io_request *req)
 	assert(SPDK_COUNTOF(req_len) == SPDK_COUNTOF(req_off));
 
 	for (i = 0; i < req->nseg; i++) {
-		iovs[i].base = spdk_zmalloc(req_off[i] + req_len[i], 0x4000, NULL);
+		iovs[i].base = spdk_aligned_zmalloc(req_off[i] + req_len[i], 0x4000, NULL);
 		iovs[i].offset = req_off[i];
 		iovs[i].len = req_len[i];
 	}
@@ -286,7 +286,7 @@ static void build_io_request_10(struct io_request *req)
 	assert(SPDK_COUNTOF(req_len) == SPDK_COUNTOF(req_off));
 
 	for (i = 0; i < req->nseg; i++) {
-		iovs[i].base = spdk_zmalloc(req_off[i] + req_len[i], 0x4000, NULL);
+		iovs[i].base = spdk_aligned_zmalloc(req_off[i] + req_len[i], 0x4000, NULL);
 		iovs[i].offset = req_off[i];
 		iovs[i].len = req_len[i];
 	}
@@ -304,10 +304,10 @@ free_req(struct io_request *req)
 	}
 
 	for (i = 0; i < req->nseg; i++) {
-		spdk_free(req->iovs[i].base - req->misalign);
+		spdk_aligned_free(req->iovs[i].base - req->misalign);
 	}
 
-	spdk_free(req);
+	spdk_aligned_free(req);
 }
 
 static int
@@ -338,7 +338,7 @@ writev_readv_tests(struct dev *dev, nvme_build_io_req_fn_t build_io_fn, const ch
 		return 0;
 	}
 
-	req = spdk_zmalloc(sizeof(*req), 0, NULL);
+	req = spdk_aligned_zmalloc(sizeof(*req), 0, NULL);
 	if (!req) {
 		fprintf(stderr, "Allocate request failed\n");
 		return 0;

--- a/test/lib/nvme/unit/nvme_ns_cmd_c/nvme_ns_cmd_ut.c
+++ b/test/lib/nvme/unit/nvme_ns_cmd_c/nvme_ns_cmd_ut.c
@@ -597,7 +597,7 @@ test_nvme_ns_cmd_dataset_management(void)
 	CU_ASSERT(g_request->cmd.nsid == ns.id);
 	CU_ASSERT(g_request->cmd.cdw10 == 0);
 	CU_ASSERT(g_request->cmd.cdw11 == SPDK_NVME_DSM_ATTR_DEALLOCATE);
-	spdk_free(g_request->payload.u.contig);
+	spdk_aligned_free(g_request->payload.u.contig);
 	nvme_free_request(g_request);
 
 	/* TRIM 256 LBAs */
@@ -609,7 +609,7 @@ test_nvme_ns_cmd_dataset_management(void)
 	CU_ASSERT(g_request->cmd.nsid == ns.id);
 	CU_ASSERT(g_request->cmd.cdw10 == 255u);
 	CU_ASSERT(g_request->cmd.cdw11 == SPDK_NVME_DSM_ATTR_DEALLOCATE);
-	spdk_free(g_request->payload.u.contig);
+	spdk_aligned_free(g_request->payload.u.contig);
 	nvme_free_request(g_request);
 
 	rc = spdk_nvme_ns_cmd_dataset_management(&ns, &qpair, SPDK_NVME_DSM_ATTR_DEALLOCATE,
@@ -756,7 +756,7 @@ test_nvme_ns_cmd_reservation_register(void)
 
 	CU_ASSERT(g_request->cmd.cdw10 == tmp_cdw10);
 
-	spdk_free(g_request->payload.u.contig);
+	spdk_aligned_free(g_request->payload.u.contig);
 	nvme_free_request(g_request);
 	free(payload);
 	cleanup_after_test(&qpair);
@@ -794,7 +794,7 @@ test_nvme_ns_cmd_reservation_release(void)
 
 	CU_ASSERT(g_request->cmd.cdw10 == tmp_cdw10);
 
-	spdk_free(g_request->payload.u.contig);
+	spdk_aligned_free(g_request->payload.u.contig);
 	nvme_free_request(g_request);
 	free(payload);
 	cleanup_after_test(&qpair);
@@ -832,7 +832,7 @@ test_nvme_ns_cmd_reservation_acquire(void)
 
 	CU_ASSERT(g_request->cmd.cdw10 == tmp_cdw10);
 
-	spdk_free(g_request->payload.u.contig);
+	spdk_aligned_free(g_request->payload.u.contig);
 	nvme_free_request(g_request);
 	free(payload);
 	cleanup_after_test(&qpair);
@@ -864,7 +864,7 @@ test_nvme_ns_cmd_reservation_report(void)
 
 	CU_ASSERT(g_request->cmd.cdw10 == (size / 4));
 
-	spdk_free(g_request->payload.u.contig);
+	spdk_aligned_free(g_request->payload.u.contig);
 	nvme_free_request(g_request);
 	free(payload);
 	cleanup_after_test(&qpair);

--- a/test/lib/scsi/lun/lun_ut.c
+++ b/test/lib/scsi/lun/lun_ut.c
@@ -96,7 +96,7 @@ spdk_get_task(uint32_t *owner_task_ctr)
 }
 
 void *
-spdk_malloc(size_t size, size_t align, uint64_t *phys_addr)
+spdk_aligned_malloc(size_t size, size_t align, uint64_t *phys_addr)
 {
 	void *buf = malloc(size);
 	if (phys_addr)
@@ -105,7 +105,7 @@ spdk_malloc(size_t size, size_t align, uint64_t *phys_addr)
 }
 
 void *
-spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
+spdk_aligned_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
 {
 	void *buf = calloc(size, 1);
 	if (phys_addr)
@@ -114,7 +114,7 @@ spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
 }
 
 void
-spdk_free(void *buf)
+spdk_aligned_free(void *buf)
 {
 	free(buf);
 }

--- a/test/lib/scsi/scsi_bdev/scsi_bdev_ut.c
+++ b/test/lib/scsi/scsi_bdev/scsi_bdev_ut.c
@@ -45,7 +45,7 @@ SPDK_LOG_REGISTER_TRACE_FLAG("scsi", SPDK_TRACE_SCSI)
 struct spdk_scsi_globals g_spdk_scsi;
 
 void *
-spdk_malloc(size_t size, size_t align, uint64_t *phys_addr)
+spdk_aligned_malloc(size_t size, size_t align, uint64_t *phys_addr)
 {
 	void *buf = malloc(size);
 	if (phys_addr)
@@ -55,7 +55,7 @@ spdk_malloc(size_t size, size_t align, uint64_t *phys_addr)
 }
 
 void *
-spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
+spdk_aligned_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
 {
 	void *buf = calloc(size, 1);
 	if (phys_addr)
@@ -65,7 +65,7 @@ spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
 }
 
 void
-spdk_free(void *buf)
+spdk_aligned_free(void *buf)
 {
 	free(buf);
 }

--- a/test/lib/test_env.c
+++ b/test/lib/test_env.c
@@ -39,7 +39,7 @@
 #include "spdk/env.h"
 
 void *
-spdk_malloc(size_t size, size_t align, uint64_t *phys_addr)
+spdk_aligned_malloc(size_t size, size_t align, uint64_t *phys_addr)
 {
 	void *buf = NULL;
 	if (posix_memalign(&buf, align, size)) {
@@ -52,9 +52,9 @@ spdk_malloc(size_t size, size_t align, uint64_t *phys_addr)
 }
 
 void *
-spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
+spdk_aligned_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
 {
-	void *buf = spdk_malloc(size, align, phys_addr);
+	void *buf = spdk_aligned_malloc(size, align, phys_addr);
 
 	if (buf != NULL) {
 		memset(buf, 0, size);
@@ -63,12 +63,12 @@ spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr)
 }
 
 void *
-spdk_realloc(void *buf, size_t size, size_t align, uint64_t *phys_addr)
+spdk_aligned_realloc(void *buf, size_t size, size_t align, uint64_t *phys_addr)
 {
 	return realloc(buf, size);
 }
 
-void spdk_free(void *buf)
+void spdk_aligned_free(void *buf)
 {
 	free(buf);
 }

--- a/test/lib/util/bit_array/bit_array_ut.c
+++ b/test/lib/util/bit_array/bit_array_ut.c
@@ -38,13 +38,13 @@
 #include "bit_array.c"
 
 void *
-spdk_realloc(void *buf, size_t size, size_t align, uint64_t *phys_addr)
+spdk_aligned_realloc(void *buf, size_t size, size_t align, uint64_t *phys_addr)
 {
 	return realloc(buf, size);
 }
 
 void
-spdk_free(void *buf)
+spdk_aligned_free(void *buf)
 {
 	free(buf);
 }


### PR DESCRIPTION
  - rename spdk_malloc to spdk_aligned_malloc
  - rename spdk_zmalloc to spdk_aligned_zmalloc
  - rename spdk_realloc to spdk_aligned_realloc
  - rename spdk_free to spdk_aligned_free

  These APIs should be used for abstracting POSIX malloc, etc.
  routines.