### PR TITLE
copy: Replace rte_memcpy with regular memcpy

### DIFF
--- a/lib/copy/copy_engine.c
+++ b/lib/copy/copy_engine.c
@@ -37,9 +37,7 @@
 #include <stdio.h>
 #include <errno.h>
 
-#include <rte_config.h>
-#include <rte_memcpy.h>
-
+#include "spdk/env.h"
 #include "spdk/log.h"
 #include "spdk/io_channel.h"
 
@@ -112,7 +110,8 @@ mem_copy_submit(void *cb_arg, struct spdk_io_channel *ch, void *dst, void *src, 
 {
 	struct spdk_copy_task *copy_req;
 
-	rte_memcpy(dst, src, (size_t)nbytes);
+	memcpy(dst, src, (size_t)nbytes);
+
 	copy_req = (struct spdk_copy_task *)((uintptr_t)cb_arg -
 					     offsetof(struct spdk_copy_task, offload_ctx));
 	cb(copy_req, 0);


### PR DESCRIPTION
Eliminate rte_memcpy dependency by replacing it with
regular memcpy. This may impact performance, but the only
use of rte_memcpy was in the malloc bdev which is for
testing only.

Change-Id: I3e8592cb08262272518ec3d29ea165b4e8f48a5c