### PR TITLE
vagrant: fix Vagrant provisioning

### DIFF
--- a/scripts/vagrant/build.sh
+++ b/scripts/vagrant/build.sh
@@ -33,7 +33,7 @@ echo DISTRIB_CODENAME: $DISTRIB_CODENAME
 echo DISTRIB_DESCRIPTION: $DISTRIB_DESCRIPTION
 
 cd $SPDK_DIR
-$SUDOCMD ./scripts/pkgdep.sh
+./scripts/pkgdep.sh
 $SUDOCMD ./configure --enable-debug
 $SUDOCMD make clean
 $SUDOCMD make -j2


### PR DESCRIPTION
Install dependencies under 'root' user.

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>