### PR TITLE
bdev_virtio: fix logging with enabled debug

### DIFF
--- a/lib/bdev/virtio/rte_virtio/virtio_logs.h
+++ b/lib/bdev/virtio/rte_virtio/virtio_logs.h
@@ -36,6 +36,11 @@
 
 #include <rte_log.h>
 
+/* Make sure DEBUG macro doesn't shadow DEBUG log level */
+#ifdef DEBUG
+#undef DEBUG
+#endif
+
 #ifdef RTE_LIBRTE_VIRTIO_DEBUG_INIT
 #define PMD_INIT_LOG(level, fmt, args...) \
 	RTE_LOG(level, PMD, "%s(): " fmt "\n", __func__, ## args)

--- a/lib/bdev/virtio/rte_virtio/virtio_user/virtio_user_dev.c
+++ b/lib/bdev/virtio/rte_virtio/virtio_user/virtio_user_dev.c
@@ -266,7 +266,7 @@ virtio_user_dev_init(char *path, int queues, int queue_size)
 	}
 
 	if (dev->max_queues > max_queues) {
-		PMD_INIT_LOG(ERR, "%d queues requested but only %d supported", dev->max_queues, max_queues);
+		PMD_INIT_LOG(ERR, "%d queues requested but only %lu supported", dev->max_queues, max_queues);
 		free(hw);
 		free(dev);
 		return NULL;


### PR DESCRIPTION
Make sure DEBUG macro is not defined while processing log macros,
otherwise DEBUG (which should be passed as is down to RTE_LOG and
concatenated with RTE_LOG_ prefix) gets substituted too early:

In file included from /spdk/dpdk/build/include/rte_debug.h:46:0,
                 from /spdk/dpdk/build/include/rte_pci.h:85,
                 from rte_virtio/virtio_dev.c:48:
rte_virtio/virtio_dev.c: In function ‘virtio_init_vring’:
/spdk/dpdk/build/include/rte_log.h:333:11: error: ‘RTE_LOG_1’ undeclared (first use in this function)
   rte_log(RTE_LOG_ ## l,     \
           ^
rte_virtio/virtio_logs.h:41:2: note: in expansion of macro ‘RTE_LOG’
  RTE_LOG(level, PMD, "%s(): " fmt "\n", __func__, ## args)
  ^
rte_virtio/virtio_logs.h:42:31: note: in expansion of macro ‘PMD_INIT_LOG’
 #define PMD_INIT_FUNC_TRACE() PMD_INIT_LOG(DEBUG, " >>")
                               ^
rte_virtio/virtio_dev.c:82:2: note: in expansion of macro ‘PMD_INIT_FUNC_TRACE’
  PMD_INIT_FUNC_TRACE();

While at this, change format string type specifier to the correct one.

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>