### PR TITLE
log: enhance debug trace flag usage

### DIFF
--- a/lib/log/log.c
+++ b/lib/log/log.c
@@ -247,7 +247,24 @@ set_trace_flag(const char *name, bool value)
 int
 spdk_log_set_trace_flag(const char *name)
 {
-	return set_trace_flag(name, true);
+  int ret = 0;
+  char *tok = NULL;
+  char *copy_name = strdup(name);
+
+  if (copy_name == NULL)
+    return -1;
+
+  tok = strtok(copy_name, ",");
+  while (tok != NULL) {
+    ret = set_trace_flag(tok, true);
+    if (ret < 0) {
+      free(copy_name);
+      return ret;
+    }
+    tok = strtok(NULL, ",");
+  }
+  free(copy_name);
+  return ret;
 }
 
 int


### PR DESCRIPTION
Previously, trace flag can only use 'all' to enable all flags or
use single one flag. This change makes it allowed to accept multiple
flags separated by ','.

For example, "-t nvme,bdev,aio" to enable nvme bdev aio flags.