### PR TITLE
scripts/vagrant: add vagrant-libvirt provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
-## Contributing
+# Contributing
 
 Please see the [SPDK development guide](http://www.spdk.io/development/) for information on how to contribute to SPDK.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
-# Contributing
+## Contributing
 
 Please see the [SPDK development guide](http://www.spdk.io/development/) for information on how to contribute to SPDK.

--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -8,6 +8,10 @@ Vagrant.configure(2) do |config|
   if distro == 'centos7'
     config.vm.box = "puppetlabs/centos-7.2-64-nocm"
     config.ssh.insert_key = false
+    # Puppetlabs does not provide libvirt Box
+    config.vm.provider :libvirt do |libvirt|
+       config.vm.box = "centos/7"
+    end if Vagrant.has_plugin?('vagrant-libvirt')
   else
     config.vm.box = "puppetlabs/ubuntu-16.04-64-nocm"
   end
@@ -67,4 +71,30 @@ Vagrant.configure(2) do |config|
       vb.customize ["setextradata", :id, "VBoxInternal/CPUM/SSE4.1", "1"]
       vb.customize ["setextradata", :id, "VBoxInternal/CPUM/SSE4.2", "1"]
   end
+
+  # libvirt configuration need modern Qemu(tested on 2.10) & vagrant-libvirt in version 0.0.39+
+  # This setup was Tested on Fedora 27
+  # There are few limitation for SElinux - The file added outside libvirt must have proper SE ACL policy or setenforce 0
+  config.vm.provider "libvirt" do |libvirt|
+      #The nvme disk image must be created outside by
+      #qemu-img create -f raw <your_virtual_HD_filename.img> <size>M
+      libvirt.qemuargs :value => "-drive"
+      libvirt.qemuargs :value => "file=/path_to/nvme_disk.img,if=none,id=D22"
+      libvirt.qemuargs :value => "-device"
+      libvirt.qemuargs :value => "nvme,drive=D22,serial=1234"
+ 
+      libvirt.driver = "kvm"
+      libvirt.graphics_type = "spice"
+      libvirt.memory = "#{vmram}"
+      libvirt.cpus = "#{vmcpu}"
+      libvirt.video_type = "qxl"
+      #Optional field if there are more storage pools than default
+      #libvirt.storage_pool_name = "vm"
+	  # rsync the vpp directory if provision hasn't happened yet
+      unless File.exist? (".vagrant/machines/default/libvirt/action_provision")
+        config.vm.synced_folder "../../", "/spdk", type: "rsync"
+      end
+
+   end
+
 end

--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -78,11 +78,19 @@ Vagrant.configure(2) do |config|
   config.vm.provider "libvirt" do |libvirt|
       #The nvme disk image must be created outside by
       #qemu-img create -f raw <your_virtual_HD_filename.img> <size>M
+
+      nvme_disk = 'nvme_disk.img'
+      unless File.exist? (nvme_disk)
+       system("qemu-img create -f raw nvme_disk.img 1024M")
+       system("chcon -t svirt_image_t nvme_disk.img")
+       system("chmod a+rwx nvme_disk.img")
+      end
+      cwd_dir = File.expand_path(ENV['PWD'])
+      image_string="file=" << cwd_dir << "/" << nvme_disk << ",if=none,id=D22"
       libvirt.qemuargs :value => "-drive"
-      libvirt.qemuargs :value => "file=/path_to/nvme_disk.img,if=none,id=D22"
+      libvirt.qemuargs :value => image_string
       libvirt.qemuargs :value => "-device"
       libvirt.qemuargs :value => "nvme,drive=D22,serial=1234"
- 
       libvirt.driver = "kvm"
       libvirt.graphics_type = "spice"
       libvirt.memory = "#{vmram}"


### PR DESCRIPTION
This patch add additional provider to vagrant. 

Restrictions:
Image for nvme must be created outside libvirt due to limitation of current libvirt implementation.
We must pass qemu arguments directly.

In SELinux environments like Fedora 27 There must be set proper ACL for nvme file or setenforce 0.
There is added official centos/7 repository.

This implementation need up to date packages:
vagrant-libvirt (0.0.39+)
Qemu 2.10

Signed-off-by: Daniel Mrzyglod <daniel.mrzyglod@gmail.com>