### PR TITLE
bdev: Enumerate virtio-scsi devices from 0

### DIFF
--- a/lib/bdev/virtio/bdev_virtio.c
+++ b/lib/bdev/virtio/bdev_virtio.c
@@ -151,7 +151,7 @@ virtio_pci_scsi_dev_create_cb(struct virtio_pci_ctx *pci_ctx)
 	}
 
 	vdev = &svdev->vdev;
-	name = spdk_sprintf_alloc("VirtioScsi%"PRIu32, ++pci_dev_counter);
+	name = spdk_sprintf_alloc("VirtioScsi%"PRIu32, pci_dev_counter++);
 	if (name == NULL) {
 		free(vdev);
 		return -1;


### PR DESCRIPTION
Starting with b9482461, virtio-scsi devices are enumerated from 1. This
is a change in previous behaviour where devices were enumerated from 0.
This commit restore the behaviour of the last stable SPDK release.

Signed-off-by: Felipe Franciosi <felipe@nutanix.com>