### PR TITLE
nvmf/rdma: decrement r/w counter if ibv_post_send fails

### DIFF
--- a/lib/nvmf/rdma.c
+++ b/lib/nvmf/rdma.c
@@ -493,6 +493,11 @@ request_transfer_in(struct spdk_nvmf_request *req)
 	rc = ibv_post_send(rqpair->cm_id->qp, &rdma_req->data.wr, &bad_wr);
 	if (rc) {
 		SPDK_ERRLOG("Unable to transfer data from host to target\n");
+
+		/* Decrement r/w counter back since data transfer
+		 * has not started.
+		 */
+		rqpair->cur_rdma_rw_depth--;
 		return -1;
 	}
 
@@ -559,6 +564,13 @@ request_transfer_out(struct spdk_nvmf_request *req)
 	rc = ibv_post_send(rqpair->cm_id->qp, send_wr, &bad_send_wr);
 	if (rc) {
 		SPDK_ERRLOG("Unable to send response capsule\n");
+
+		if (rdma_req->data.wr.opcode == IBV_WR_RDMA_WRITE) {
+			/* Decrement r/w counter back since data transfer
+			 * has not started.
+			 */
+			rqpair->cur_rdma_rw_depth--;
+		}
 	}
 
 	return rc;


### PR DESCRIPTION
The outstanding r/w requests counter is not decremented
back if IB r/w request fails.

As the result, the rdma qpair stops pumping the requests
after the number of ibv_post_send failures reaches
the threshold for outstanding r/w requests for that qpair.

The patch decrements qpair's r/w counter back in case of
ibv_post_send returns an error.

Change-Id: I8fa0f2905974a50037034962e4d2a001290a06a9