### PR TITLE
Fixes a bug in detect_cc.sh when using ICC

### DIFF
--- a/scripts/detect_cc.sh
+++ b/scripts/detect_cc.sh
@@ -52,8 +52,8 @@ for i in "$@"; do
 	esac
 done
 
-CC_TYPE=$($CC -v 2>&1 | grep -o -E '\w+ version' | head -1 | awk '{ print $1 }')
-CXX_TYPE=$($CXX -v 2>&1 | grep -o -E '\w+ version' | head -1 | awk '{ print $1 }')
+CC_TYPE=$($CC -v 2>&1 | grep -o -E '\w+ version' | head -1 | awk '{ print $1 }' | head -1)
+CXX_TYPE=$($CXX -v 2>&1 | grep -o -E '\w+ version' | head -1 | awk '{ print $1 }' | head -1)
 LD_TYPE=$(ld -v 2>&1 | awk '{print $2}')
 
 if [ "$CC_TYPE" != "$CXX_TYPE" ]; then


### PR DESCRIPTION
'detect_cc.sh' runs the command "$CC -v" to get the version of the C compiler, and pipes the output to grep and then on to awk to get the type of compiler. With GCC, the output is:
```
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/4.8.5/lto-wrapper
Target: x86_64-redhat-linux
Configured with: ../configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-bootstrap --enable-shared --enable-threads=posix --enable-checking=release --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-linker-hash-style=gnu --enable-languages=c,c++,objc,obj-c++,java,fortran,ada,go,lto --enable-plugin --enable-initfini-array --disable-libgcj --with-isl=/builddir/build/BUILD/gcc-4.8.5-20150702/obj-x86_64-redhat-linux/isl-install --with-cloog=/builddir/build/BUILD/gcc-4.8.5-20150702/obj-x86_64-redhat-linux/cloog-install --enable-gnu-indirect-function --with-tune=generic --with-arch_32=x86-64 --build=x86_64-redhat-linux
Thread model: posix
gcc version 4.8.5 20150623 (Red Hat 4.8.5-16) (GCC) 
```
in which the string "version" only occurs once.

With ICC, however, the output is:
`icc version 18.0.1 (gcc version 4.8.5 compatibility)`
The 2nd occurrence of "version" causes detect_cc.sh's output to be in an unexpected format, leading to this error:
`/path/to/spdk/mk/cc.mk:5: *** missing separator.  Stop.`

Anyway, this patch fixes the issue, at least on my system (CentOS 7.4/x86_64 using ICC 18.0.1)