### PR TITLE
go: empty Go package

### DIFF
--- a/go/spdk.go
+++ b/go/spdk.go
@@ -1,0 +1,50 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright (c) Intel Corporation.
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// spdk might one day provide Go bindings for the SPDK RPC API.
+// At the moment all that it does is allowing a Go project
+// to vendor in the SPDK source code via dep with this
+// in Gopkg.toml:
+//
+// required = ["github.com/spdk/spdk/go"]
+//
+// [prune]
+//  go-tests = true
+//  unused-packages = true
+//
+//  [[prune.project]]
+//    name = "github.com/spdk/spdk/go"
+//    go-tests = false
+//    unused-packages = false
+
+package spdk


### PR DESCRIPTION
The only purpose at the moment is to allow vendoring of the SPDK
source code into other Go projects which manage dependencies with
the "dep" tool. That tool is designed for Go projects and as a sanity
check rejects any dependency which does not have at least one Go file.

Change-Id: I22458d0895729ad7d8ea53e7541e9089da1d448a