### PR TITLE
Don't build lib/cunit if tests are disabled

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -34,9 +34,10 @@
 SPDK_ROOT_DIR := $(abspath $(CURDIR)/..)
 include $(SPDK_ROOT_DIR)/mk/spdk.common.mk
 
-DIRS-y += bdev blob blobfs conf copy cunit event json jsonrpc \
+DIRS-y += bdev blob blobfs conf copy event json jsonrpc \
           log lvol net rpc sock thread trace util nvme nvmf scsi ioat \
 	  ut_mock iscsi
+DIRS-$(CONFIG_TESTS) += cunit
 ifeq ($(OS),Linux)
 DIRS-y += nbd
 DIRS-$(CONFIG_VHOST) += vhost


### PR DESCRIPTION
This makes it possible to build SPDK on a machine which doesn't have
CUnit installed.