### PR TITLE
Update Vagrantfile to support Ubuntu 18.04

### DIFF
--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -18,9 +18,9 @@ Vagrant.configure(2) do |config|
     config.vm.box = "puppetlabs/ubuntu-16.04-64-nocm"
     config.vm.box_version = "1.0.0"
   when "ubuntu18"
-    # See: https://app.vagrantup.com/bento/boxes/ubuntu-18.04
-    config.vm.box = "bento/ubuntu-18.04"
-    config.vm.box_version = "201803.24.0"
+    # See: https://app.vagrantup.com/generic/boxes/ubuntu1804/versions/1.8.40
+    config.vm.box = "generic/ubuntu1804"
+    config.vm.box_version = "1.8.40"    
   when "fedora26"
     #See: https://app.vagrantup.com/generic/boxes/fedora2
     config.vm.box = "generic/fedora26"


### PR DESCRIPTION
bento/ubuntu-18.04 was not supported, but generic/ubuntu1804.  If this was done on purpose then ignore this pull request.