### PR TITLE
Add resize function for bdev with ceph rbd backend

### DIFF
--- a/lib/bdev/rbd/bdev_rbd.c
+++ b/lib/bdev/rbd/bdev_rbd.c
@@ -173,6 +173,43 @@ bdev_rbd_exit(rbd_image_t image)
 	rbd_close(image);
 }
 
+static int
+bdev_rbd_resize(void *arg, uint64_t offset)
+{
+	int ret;
+	rados_t cluster = NULL;
+	rados_ioctx_t io_ctx = NULL;
+	rbd_image_t image = NULL;
+	struct bdev_rbd *rbd = arg;
+
+	ret = bdev_rados_context_init(rbd->pool_name, &cluster, &io_ctx);
+	if (ret < 0) {
+		SPDK_ERRLOG("Failed to create rados context for rbd_pool=%s\n",
+			    rbd->pool_name);
+		return -1;
+	}
+	ret = rbd_open(io_ctx, rbd->rbd_name, &image, NULL);
+	if (ret < 0) {
+		SPDK_ERRLOG("Failed to open specified rbd device %s\n", rbd->rbd_name);
+		goto err;
+	}
+        ret = rbd_resize(image, offset);
+        if (ret < 0) {
+		SPDK_ERRLOG("Failed to resize specified rbd device %s\n", rbd->rbd_name);
+                goto err;
+        }
+
+	rbd_close(image);
+	rados_ioctx_destroy(io_ctx);
+	rados_shutdown(cluster);
+	return 0;
+err:
+	rbd_close(image);
+	rados_ioctx_destroy(io_ctx);
+	rados_shutdown(cluster);
+	return -1;
+}
+
 static void
 bdev_rbd_finish_aiocb(rbd_completion_t cb, void *arg)
 {
@@ -671,6 +708,30 @@ spdk_bdev_rbd_delete(struct spdk_bdev *bdev, spdk_delete_rbd_complete cb_fn, voi
 	}
 
 	spdk_bdev_unregister(bdev, cb_fn, cb_arg);
+}
+
+void
+spdk_bdev_rbd_resize(struct spdk_bdev *bdev, uint64_t size, spdk_resize_rbd_complete cb_fn, void *cb_arg)
+{
+       int rbderrno = 0;
+       rbderrno = bdev_rbd_resize(bdev->ctxt, size);
+       if (rbderrno != 0) {
+           SPDK_ERRLOG("Could not resize rbd with error no: %d.\n",
+                       rbderrno);
+           cb_fn(cb_arg, rbderrno);
+           return;
+       }
+
+       rbderrno = spdk_bdev_notify_blockcnt_change(bdev, size / bdev->blocklen);
+       if (rbderrno != 0) {
+           SPDK_ERRLOG("Could not change num blocks for bdev rbd with error no: %d.\n",
+			    rbderrno);
+           cb_fn(cb_arg, -ENODEV);
+           return;
+       }
+       ((struct bdev_rbd *)bdev)->info.size = size;
+       cb_fn(cb_arg, 0);
+       return;
 }
 
 static int

--- a/lib/bdev/rbd/bdev_rbd.h
+++ b/lib/bdev/rbd/bdev_rbd.h
@@ -40,6 +40,8 @@
 
 typedef void (*spdk_delete_rbd_complete)(void *cb_arg, int bdeverrno);
 
+typedef void (*spdk_resize_rbd_complete)(void *cb_arg, int bdeverrno);
+
 struct spdk_bdev *spdk_bdev_rbd_create(const char *name, const char *pool_name,
 				       const char *rbd_name, uint32_t block_size);
 /**
@@ -51,5 +53,9 @@ struct spdk_bdev *spdk_bdev_rbd_create(const char *name, const char *pool_name,
  */
 void spdk_bdev_rbd_delete(struct spdk_bdev *bdev, spdk_delete_rbd_complete cb_fn,
 			  void *cb_arg);
+
+void
+spdk_bdev_rbd_resize(struct spdk_bdev *bdev, uint64_t size,
+                     spdk_resize_rbd_complete cb_fn, void *cb_arg);
 
 #endif /* SPDK_BDEV_RBD_H */

--- a/lib/bdev/rbd/bdev_rbd_rpc.c
+++ b/lib/bdev/rbd/bdev_rbd_rpc.c
@@ -155,3 +155,76 @@ invalid:
 	spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS, spdk_strerror(-rc));
 }
 SPDK_RPC_REGISTER("delete_rbd_bdev", spdk_rpc_delete_rbd_bdev, SPDK_RPC_RUNTIME)
+
+struct rpc_resize_rbd {
+        char *name;
+        uint64_t size;
+};
+
+static void
+free_rpc_resize_rbd(struct rpc_resize_rbd *req)
+{
+        free(req->name);
+}
+
+static const struct spdk_json_object_decoder rpc_resize_rbd_decoders[] = {
+        {"name", offsetof(struct rpc_resize_rbd, name), spdk_json_decode_string, true},
+        {"size", offsetof(struct rpc_resize_rbd, size), spdk_json_decode_uint64},
+};
+
+static void
+_spdk_rpc_resize_rbd_bdev_cb(void *cb_arg, int rbderrno)
+{
+        struct spdk_json_write_ctx *w;
+        struct spdk_jsonrpc_request *request = cb_arg;
+
+        if (rbderrno != 0) {
+                goto invalid;
+        }
+
+        w = spdk_jsonrpc_begin_result(request);
+        if (w == NULL) {
+                return;
+        }
+
+        spdk_json_write_bool(w, true);
+        spdk_jsonrpc_end_result(request, w);
+        return;
+
+invalid:
+        spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS,
+                                         spdk_strerror(-rbderrno));
+}
+
+
+
+static void
+spdk_rpc_resize_rbd_bdev(struct spdk_jsonrpc_request *request,
+                         const struct spdk_json_val *params)
+{
+        struct rpc_resize_rbd req = {NULL};
+        struct spdk_bdev *bdev;
+        int rc;
+
+        if (spdk_json_decode_object(params, rpc_resize_rbd_decoders,
+					SPDK_COUNTOF(rpc_resize_rbd_decoders),
+                                    &req)) {
+                rc = -EINVAL;
+                goto invalid;
+        }
+
+        bdev = spdk_bdev_get_by_name(req.name);
+        if (bdev == NULL) {
+                rc = -ENODEV;
+                goto invalid;
+        }
+
+        spdk_bdev_rbd_resize(bdev, req.size, _spdk_rpc_resize_rbd_bdev_cb, request);
+        free_rpc_resize_rbd(&req);
+        return;
+
+invalid:
+	free_rpc_resize_rbd(&req);
+	spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS, spdk_strerror(-rc));
+}
+SPDK_RPC_REGISTER("resize_rbd_bdev", spdk_rpc_resize_rbd_bdev, SPDK_RPC_RUNTIME)

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -344,6 +344,17 @@ if __name__ == "__main__":
     p.set_defaults(func=delete_rbd_bdev)
 
     @call_cmd
+    def resize_rbd_bdev(args):
+        rpc.bdev.resize_rbd_bdev(args.client,
+                                 name=args.name, size=args.size * 1024 * 1024)
+
+    p = subparsers.add_parser('resize_rbd_bdev',
+                              help='resize a bdev with ceph rbd backend')
+    p.add_argument('name', help='rbd bdev name')
+    p.add_argument('size', help='new size in MiB for this bdev', type=int)
+    p.set_defaults(func=resize_rbd_bdev)
+
+    @call_cmd
     def construct_error_bdev(args):
         print(rpc.bdev.construct_error_bdev(args.client,
                                             base_name=args.base_name))

--- a/scripts/rpc/bdev.py
+++ b/scripts/rpc/bdev.py
@@ -290,6 +290,14 @@ def delete_rbd_bdev(client, name):
     return client.call('delete_rbd_bdev', params)
 
 
+def resize_rbd_bdev(client, name, size):
+    params = {
+        'name': name,
+        'size': size,
+    }
+    return client.call('resize_rbd_bdev', params)
+
+
 def construct_error_bdev(client, base_name):
     """Construct an error injection block device.
 


### PR DESCRIPTION
This patch is to resize a bdev with ceph rbd backend and the backend
rbd image.

Signed-off-by: Zhipeng LU <luzhipeng@uniudc.com>