### PR TITLE
 add memory barrier process completions for arm64

### DIFF
--- a/lib/nvme/nvme_pcie.c
+++ b/lib/nvme/nvme_pcie.c
@@ -2084,7 +2084,7 @@ nvme_pcie_qpair_process_completions(struct spdk_nvme_qpair *qpair, uint32_t max_
 		if (cpl->status.p != pqpair->phase) {
 			break;
 		}
-#ifdef __PPC64__
+#if defined(__PPC64__) || defined(__aarch64__)
 		/*
 		 * This memory barrier prevents reordering of:
 		 * - load after store from/to tr


### PR DESCRIPTION
when run  perf on arm64,  it will assert:  *ERROR*: cpl does not map to outstanding cmd
Because arm64 has less strict memory ordering behaviour than x86,  arm64  should introduce a memory barrier to prevent possible reordering of tracker and cpl access.