### PR TITLE
scripts/pkgdep: update SUSE distros rorecognition

### DIFF
--- a/scripts/pkgdep.sh
+++ b/scripts/pkgdep.sh
@@ -92,7 +92,7 @@ elif [ -f /etc/debian_version ]; then
 		"Note: Some SPDK CLI dependencies could not be installed."
 	# Additional dependencies for ISA-L used in compression
 	apt-get install -y autoconf automake libtool
-elif [ -f /etc/SuSE-release ]; then
+elif [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]; then
 	zypper install -y gcc gcc-c++ make cunit-devel libaio-devel libopenssl-devel \
 		git-core lcov python-base python-pycodestyle libuuid-devel sg3_utils pciutils
 	# Additional (optional) dependencies for showing backtrace in logs


### PR DESCRIPTION
OpenSUSE releases (OpenSUSE Leap and Tumbleweed) now use
/etc/SUSE-brand than /etc/SuSE-release as SUSE identification.
According to this change, This commit intends to update
scripts/pkgdep so that it could install packages for OpenSUSE.

Tested on OpenSUSE Leap 15.0 and latest Tumblweed.