### PR TITLE
Remove duplicate Requires: librdmacm

### DIFF
--- a/pkg/spdk.spec
+++ b/pkg/spdk.spec
@@ -40,7 +40,7 @@ BuildRequires: doxygen mscgen graphviz
 Requires: dpdk >= 17.11, numactl-libs, openssl-libs
 Requires: libiscsi, libaio, libuuid
 # NVMe over Fabrics
-Requires: librdmacm, librdmacm
+Requires: librdmacm
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 


### PR DESCRIPTION
librdmacm was being specified on the same Requires: line twice.  Remove one.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>