### PR TITLE
lib/trace: Don't initialize traces if requested num entries is 0

### DIFF
--- a/lib/trace/trace.c
+++ b/lib/trace/trace.c
@@ -87,6 +87,11 @@ spdk_trace_init(const char *shm_name, uint64_t num_entries)
 	int histories_size;
 	uint64_t lcore_offsets[SPDK_TRACE_MAX_LCORE + 1];
 
+	/* 0 entries requested - skip trace initialization */
+	if (num_entries == 0) {
+		return 0;
+	}
+
 	lcore_offsets[0] = sizeof(struct spdk_trace_flags);
 	for (i = 1; i < (int)SPDK_COUNTOF(lcore_offsets); i++) {
 		lcore_offsets[i] = spdk_get_trace_history_size(num_entries) + lcore_offsets[i - 1];


### PR DESCRIPTION
Context:
Every-time the SPDK starts, it creates a large file under `/dev/shm (130 MB in my setup) which is never removed when the application terminates.

The number of trace entries can be tuned using the SPDK runtime option `num_entries`. A value of 0 for this option considerably reduces the size of the trace file (few MBs) but it is still created.

This patch adds a special case in the code when `num_entries=0`:
the trace system would not be initialized, and the trace file would not be created in this case.

The rest of the code properly handles the case where the trace system is never initialized.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>