### PR TITLE
nvmf/rdma: Add WR batch rdma parameter

### DIFF
--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -3844,6 +3844,7 @@ no_srq                      | Optional | boolean | Disable shared receive queue 
 c2h_success                 | Optional | boolean | Disable C2H success optimization (TCP only)
 dif_insert_or_strip         | Optional | boolean | Enable DIF insert for write I/O and DIF strip for read I/O DIF (TCP only)
 sock_priority               | Optional | number  | The socket priority of the connection owned by this transport (TCP only)
+wr_batching                 | Optional | boolean | Disable work requests batching (RDMA only)
 
 ### Example:
 

--- a/etc/spdk/nvmf.conf.in
+++ b/etc/spdk/nvmf.conf.in
@@ -111,6 +111,9 @@
   # Set the maximum number outstanding I/O per shared receive queue. Relevant only for RDMA transport
   #MaxSRQDepth 4096
 
+  # Set batching for RDMA requests
+  #WRBatching True
+
 [Transport]
   # Set TCP transport type.
   Type TCP

--- a/include/spdk/nvmf.h
+++ b/include/spdk/nvmf.h
@@ -83,6 +83,7 @@ struct spdk_nvmf_transport_opts {
 	bool		no_srq;
 	bool		c2h_success;
 	bool		dif_insert_or_strip;
+	bool            wr_batching;
 	uint32_t	sock_priority;
 };
 

--- a/lib/nvmf/nvmf_rpc.c
+++ b/lib/nvmf/nvmf_rpc.c
@@ -1602,6 +1602,10 @@ static const struct spdk_json_object_decoder nvmf_rpc_create_transport_decoder[]
 		"tgt_name", offsetof(struct nvmf_rpc_create_transport_ctx, tgt_name),
 		spdk_json_decode_string, true
 	},
+	{
+		"wr_batching", offsetof(struct nvmf_rpc_create_transport_ctx, opts.wr_batching),
+		spdk_json_decode_bool, true
+	},
 };
 
 static void
@@ -1745,6 +1749,7 @@ dump_nvmf_transport(struct spdk_json_write_ctx *w, struct spdk_nvmf_transport *t
 	if (type == SPDK_NVME_TRANSPORT_RDMA) {
 		spdk_json_write_named_uint32(w, "max_srq_depth", opts->max_srq_depth);
 		spdk_json_write_named_bool(w, "no_srq", opts->no_srq);
+		spdk_json_write_named_bool(w, "wr_batching", opts->wr_batching);
 	} else if (type == SPDK_NVME_TRANSPORT_TCP) {
 		spdk_json_write_named_bool(w, "c2h_success", opts->c2h_success);
 		spdk_json_write_named_uint32(w, "sock_priority", opts->sock_priority);

--- a/module/event/subsystems/nvmf/conf.c
+++ b/module/event/subsystems/nvmf/conf.c
@@ -642,6 +642,8 @@ spdk_nvmf_parse_transport(struct spdk_nvmf_parse_transport_ctx *ctx)
 		}
 		bval = spdk_conf_section_get_boolval(ctx->sp, "NoSRQ", false);
 		opts.no_srq = bval;
+		bval = spdk_conf_section_get_boolval(ctx->sp, "WRBatching", true);
+		opts.wr_batching = bval;
 	}
 
 	if (trtype == SPDK_NVME_TRANSPORT_TCP) {

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -1684,7 +1684,8 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
                                        no_srq=args.no_srq,
                                        c2h_success=args.c2h_success,
                                        dif_insert_or_strip=args.dif_insert_or_strip,
-                                       sock_priority=args.sock_priority)
+				       sock_priority=args.sock_priority,
+				       wr_batching=args.wr_batching)
 
     p = subparsers.add_parser('nvmf_create_transport', help='Create NVMf transport')
     p.add_argument('-t', '--trtype', help='Transport type (ex. RDMA)', type=str, required=True)
@@ -1702,6 +1703,7 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('-o', '--c2h-success', action='store_false', help='Disable C2H success optimization. Relevant only for TCP transport')
     p.add_argument('-f', '--dif-insert-or-strip', action='store_true', help='Enable DIF insert/strip. Relevant only for TCP transport')
     p.add_argument('-y', '--sock-priority', help='The sock priority of the tcp connection. Relevant only for TCP transport', type=int)
+    p.add_argument('-b', '--wr-batching', action='store_true', help='Disable work requests batching. Relevant only for RDMA transport')
     p.set_defaults(func=nvmf_create_transport)
 
     def nvmf_get_transports(args):

--- a/scripts/rpc/nvmf.py
+++ b/scripts/rpc/nvmf.py
@@ -106,7 +106,8 @@ def nvmf_create_transport(client,
                           no_srq=False,
                           c2h_success=True,
                           dif_insert_or_strip=None,
-                          sock_priority=None):
+			  sock_priority=None,
+			  wr_batching=True):
     """NVMf Transport Create options.
 
     Args:
@@ -123,7 +124,7 @@ def nvmf_create_transport(client,
         no_srq: Boolean flag to disable SRQ even for devices that support it - RDMA specific (optional)
         c2h_success: Boolean flag to disable the C2H success optimization - TCP specific (optional)
         dif_insert_or_strip: Boolean flag to enable DIF insert/strip for I/O - TCP specific (optional)
-
+	wq_batching: Boolean flag to disable work requests batching - RDMA specific (optional)
     Returns:
         True or False
     """
@@ -158,6 +159,8 @@ def nvmf_create_transport(client,
         params['dif_insert_or_strip'] = dif_insert_or_strip
     if sock_priority:
         params['sock_priority'] = sock_priority
+    if wr_batching:
+	params['wr_batching'] = wr_batching
     return client.call('nvmf_create_transport', params)
 
 


### PR DESCRIPTION
With x86 and QD < 64 there is a benefit from disable batch when we have
randread IO pattern, initiators on many cores and BS = 4K.
With QD = 4 we also see benefit from disable batch for small BS( BS <
2K).

Batching is configurable with optional parameter WRBatching in
configuration file (default True).

Signed-off-by: Ivan Betsis <c_ivanb@mellanox.com>
Signed-off-by: Evgeniy Kochetov <evgeniik@mellanox.com>
Signed-off-by: Sasha Kotchubievsky <sashakot@mellanox.com>