### PR TITLE
doc/jsonrpc: Fix volume size description error

### DIFF
--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -5271,7 +5271,7 @@ Create a logical volume on a logical volume store.
 Name                    | Optional | Type        | Description
 ----------------------- | -------- | ----------- | -----------
 lvol_name               | Required | string      | Name of logical volume to create
-size                    | Required | number      | Desired size of logical volume in megabytes
+size                    | Required | number      | Desired size of logical volume in bytes
 thin_provision          | Optional | boolean     | True to enable thin provisioning
 uuid                    | Optional | string      | UUID of logical volume store to create logical volume on
 lvs_name                | Optional | string      | Name of logical volume store to create logical volume on
@@ -5441,7 +5441,7 @@ Resize a logical volume.
 Name                    | Optional | Type        | Description
 ----------------------- | -------- | ----------- | -----------
 name                    | Required | string      | UUID or alias of the logical volume to resize
-size                    | Required | number      | Desired size of the logical volume in megabytes
+size                    | Required | number      | Desired size of the logical volume in bytes
 
 ### Example
 


### PR DESCRIPTION
The function bdev_lvol_create and bdev_lvol_resize actually passes in
the size parameter as bytes instead of magebytes.

Change-Id: Id5ef604396fb71a52ee7c6c7830dc2cd5349eaf8
Signed-off-by: Haichao Li <haichao.li@arm.com>