### PR TITLE
fixed a typo in doc/blob.md

### DIFF
--- a/doc/blob.md
+++ b/doc/blob.md
@@ -225,7 +225,7 @@ with SPDK API.
 ### Error Handling
 
 Asynchronous Blobstore callbacks all include an error number that should be checked; non-zero values
-indicate and error. Synchronous calls will typically return an error value if applicable.
+indicate an error. Synchronous calls will typically return an error value if applicable.
 
 ### Asynchronous API
 


### PR DESCRIPTION
as the title there is an typo in the file doc/blob.md, and it is now fixed.
