### PR TITLE
Add libFuzzer fuzzer to integrate spdk into OSS-fuzz

### DIFF
--- a/test/fuzz/parse_json_fuzzer.cc
+++ b/test/fuzz/parse_json_fuzzer.cc
@@ -1,0 +1,48 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright (c) 2020 Mellanox Technologies LTD. All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include "spdk/json.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+
+        char *buf = (char *)malloc(size);
+
+        if (buf == NULL){
+                return 0;
+        }
+        memcpy(buf, data, size);
+        ssize_t rc = spdk_json_parse(buf, size, NULL, 0, NULL, 0);
+
+        free(buf);
+        return 0;
+}


### PR DESCRIPTION
I have been working on setting up continuous fuzzing of spdk throuh OSS-fuzz for the purpose of taking the first steps in this direction. In this context I am adding a simple fuzzer for the json parser.

For those unfamiliar with fuzzing: Fuzzing is a way of testing software applications whereby pseudo-random data is passed into a target application with the goal of finding bugs and vulnerabilities.

Google offers a free infrastructure and resources to critical open source projects to run their fuzzers continuously. If bugs are found through OSS-fuzz maintainers get notified with an email containing a link to a detailed bug reports where a stack trace and a reproducible test case can be found. 
I see that extensive work has been done already in terms of fuzzing spdk, and it should be fairly straight forward to convert the fuzzers to libFuzzer fuzzers. Unfortunately I don't have time to do that now, but I will be happy to work more on fuzzing spdk progressively. 

I have set up a draft integration on the OSS-fuzz side here: https://github.com/google/oss-fuzz/pull/4904. When the fuzzer in this PR is merged, the integration should pass. 

Signed-off-by: AdamKorcz <adam@adalogics.com>