### PR TITLE
RPC : Removed free context operation. seems to be excessive since con…

### DIFF
--- a/module/bdev/nvme/bdev_nvme_rpc.c
+++ b/module/bdev/nvme/bdev_nvme_rpc.c
@@ -242,7 +242,6 @@ rpc_bdev_nvme_attach_controller_done(void *cb_ctx, size_t bdev_count, int rc)
 
 exit:
 	free_rpc_bdev_nvme_attach_controller(&ctx->req);
-	free(ctx);
 }
 
 static void


### PR DESCRIPTION
RPC : Removed free context operation. seems to be excessive since context would be freed on populate_namespaces_cb