### PR TITLE
Updated python to python3; apt no longer recognizes 'python'

### DIFF
--- a/scripts/pkgdep/debian.sh
+++ b/scripts/pkgdep/debian.sh
@@ -4,7 +4,7 @@ VERSION_ID_NUM=$(sed 's/\.//g' <<< $VERSION_ID)
 # Includes Ubuntu, Debian
 # Minimal install
 apt-get install -y gcc g++ make libcunit1-dev libaio-dev libssl-dev libjson-c-dev libcmocka-dev \
-	uuid-dev libiscsi-dev python libncurses5-dev libncursesw5-dev python3-pip
+	uuid-dev libiscsi-dev python3 libncurses5-dev libncursesw5-dev python3-pip
 pip3 install ninja
 if ! pip3 install meson; then
 	# After recent updates pip3 on ubuntu1604 provides meson version which requires python >= 3.6.


### PR DESCRIPTION
APT no longer has a package for 'python', only 'python3' and 'python2'. The debian.sh (and therefore ubuntu.sh) script in scripts/pkgdep which handles prerequisite setup for SPDK attempts to call apt with 'python', when it should instead be 'python3' (or python2 -- but python3 is assumed already by SPDK) due to APT removing the 'python' package.

When trying to run the script, it will halt due to this error, so this fix helps prevent every user from having to manually modify 'python' to 'python3'. 