### PR TITLE
Remove unused config.h include from vmd.h

### DIFF
--- a/include/spdk/vmd.h
+++ b/include/spdk/vmd.h
@@ -16,7 +16,6 @@
 extern "C" {
 #endif
 
-#include "spdk/config.h"
 #include "spdk/env.h"
 
 /* Maximum VMD devices - up to 6 per cpu */


### PR DESCRIPTION
This change makes it possible to build `examples/nvme/perf` standalone by running `make` from that subdirectory.