### PR TITLE
NVME TP-8009 Auto-discovery of discovery controllers using mDNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### bdev
 
+Added RPCs bdev_nvme_start_mdns_discovery, bdev_nvme_get_discovery_info and
+bdev_nvme_stop_mdns_discovery to perform avahi based mDNS discovery service,
+as per Nvme TP 8009 - Automated Discovery of Ethernet Discovery Controllers.
+
 Both of interleaved and separated metadata are now supported by the malloc bdev module.
 
 Protection information is now supported by the malloc bdev module.

--- a/CONFIG
+++ b/CONFIG
@@ -201,3 +201,6 @@ CONFIG_IPSEC_MB_DIR=
 
 # Generate Storage Management Agent's protobuf interface
 CONFIG_SMA=n
+
+# Build with AVAHI support
+CONFIG_AVAHI=n

--- a/configure
+++ b/configure
@@ -116,6 +116,7 @@ function usage() {
 	echo "                           (Typically /usr/lib/llvm-VER/lib/clang/VER/lib/linux/libclang_rt.fuzzer_no_main-ARCH.a)"
 	echo " --with-sma                Generate Storage Management Agent's protobuf interface"
 	echo " --without-sma             No path required."
+	echo " --with-avahi              Build with Avahi mDNS discovery client service enabled."
 	echo ""
 	echo "Environment variables:"
 	echo ""
@@ -642,6 +643,9 @@ for i in "$@"; do
 		--without-sma)
 			CONFIG[SMA]=n
 			;;
+		--with-avahi)
+			CONFIG[AVAHI]=y
+			;;
 		--)
 			break
 			;;
@@ -1163,6 +1167,16 @@ fi
 if [[ "${CONFIG[SMA]}" = "y" ]]; then
 	if ! python3 -c 'import grpc; import grpc_tools' 2> /dev/null; then
 		echo "--with-sma requires grpcio and grpcio-tools python packages."
+		echo "Please install then re-run this script."
+		exit 1
+	fi
+fi
+
+if [[ "${CONFIG[AVAHI]}" = "y" ]]; then
+	if ! echo -e '#include <avahi-client/client.h>\n#include <avahi-common/malloc.h>\n' \
+		'int main(void) { return 0; }\n' \
+		| "${BUILD_CMD[@]}" -lavahi-client -lavahi-common - 2> /dev/null; then
+		echo "--with-avahi requires libavahi-client and libavahi-common."
 		echo "Please install then re-run this script."
 		exit 1
 	fi

--- a/configure
+++ b/configure
@@ -117,6 +117,7 @@ function usage() {
 	echo " --with-sma                Generate Storage Management Agent's protobuf interface"
 	echo " --without-sma             No path required."
 	echo " --with-avahi              Build with Avahi mDNS discovery client service enabled."
+	echo " --without-avahi           No path required."
 	echo ""
 	echo "Environment variables:"
 	echo ""
@@ -645,6 +646,9 @@ for i in "$@"; do
 			;;
 		--with-avahi)
 			CONFIG[AVAHI]=y
+			;;
+		--without-avahi)
+			CONFIG[AVAHI]=n
 			;;
 		--)
 			break

--- a/mk/spdk.common.mk
+++ b/mk/spdk.common.mk
@@ -161,6 +161,11 @@ LDFLAGS += -L$(CONFIG_URING_PATH)
 endif
 endif
 
+ifeq ($(CONFIG_AVAHI),y)
+SYS_LIBS += -lavahi-common -lavahi-client
+CFLAGS += -I
+endif
+
 IPSEC_MB_DIR=$(CONFIG_IPSEC_MB_DIR)
 
 ISAL_DIR=$(SPDK_ROOT_DIR)/isa-l

--- a/mk/spdk.common.mk
+++ b/mk/spdk.common.mk
@@ -163,7 +163,6 @@ endif
 
 ifeq ($(CONFIG_AVAHI),y)
 SYS_LIBS += -lavahi-common -lavahi-client
-CFLAGS += -I
 endif
 
 IPSEC_MB_DIR=$(CONFIG_IPSEC_MB_DIR)

--- a/module/bdev/nvme/Makefile
+++ b/module/bdev/nvme/Makefile
@@ -11,6 +11,7 @@ SO_MINOR := 0
 
 C_SRCS = bdev_nvme.c bdev_nvme_rpc.c nvme_rpc.c
 C_SRCS-$(CONFIG_NVME_CUSE) += bdev_nvme_cuse_rpc.c
+C_SRCS-$(CONFIG_AVAHI) += bdev_mdns_client.c
 
 ifeq ($(OS),Linux)
 C_SRCS += vbdev_opal.c vbdev_opal_rpc.c

--- a/module/bdev/nvme/bdev_mdns.h
+++ b/module/bdev/nvme/bdev_mdns.h
@@ -1,0 +1,21 @@
+/*   SPDX-License-Identifier: BSD-3-Clause
+ *   Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *   Copyright (c) 2019 Mellanox Technologies LTD. All rights reserved.
+ *   Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ */
+
+#ifndef SPDK_BDEV_MDNS_H
+#define SPDK_BDEV_MDNS_H
+
+#include "spdk/stdinc.h"
+
+#include "spdk/queue.h"
+#include "spdk/nvme.h"
+#include "spdk/bdev_module.h"
+
+int
+bdev_nvme_start_mdns_discovery(const char *base_name,
+                               const char *svcname,
+                               struct spdk_nvme_ctrlr_opts *drv_opts,
+                               struct nvme_ctrlr_opts *bdev_opts);
+#endif /* SPDK_BDEV_MDNS_H */

--- a/module/bdev/nvme/bdev_mdns.h
+++ b/module/bdev/nvme/bdev_mdns.h
@@ -18,4 +18,8 @@ bdev_nvme_start_mdns_discovery(const char *base_name,
                                const char *svcname,
                                struct spdk_nvme_ctrlr_opts *drv_opts,
                                struct nvme_ctrlr_opts *bdev_opts);
+int
+bdev_nvme_stop_mdns_discovery(const char *name);
+void
+bdev_nvme_get_mdns_discovery_info(struct spdk_json_write_ctx *w);
 #endif /* SPDK_BDEV_MDNS_H */

--- a/module/bdev/nvme/bdev_nvme.c
+++ b/module/bdev/nvme/bdev_nvme.c
@@ -5239,9 +5239,9 @@ create_discovery_entry_ctx(struct discovery_ctx *ctx, struct spdk_nvme_transport
 		DISCOVERY_ERRLOG(ctx, "could not allocate new entry_ctx\n");
 		return NULL;
 	}
-
 	new_ctx->ctx = ctx;
 	memcpy(&new_ctx->trid, trid, sizeof(*trid));
+	DISCOVERY_ERRLOG(ctx, "PARAMLOG: trid: %p ctx->name: %s new_ctx->trid.traddr: %s new_ctx->trid.trsvcid: %s new_ctx->trid.adrfam %d new_ctx->trid.trtype %d\n", trid, ctx->name, new_ctx->trid.traddr, new_ctx->trid.trsvcid, new_ctx->trid.adrfam, new_ctx->trid.trtype);
 	spdk_nvme_ctrlr_get_default_ctrlr_opts(&new_ctx->drv_opts, sizeof(new_ctx->drv_opts));
 	snprintf(new_ctx->drv_opts.hostnqn, sizeof(new_ctx->drv_opts.hostnqn), "%s", ctx->hostnqn);
 	return new_ctx;
@@ -5527,6 +5527,7 @@ bdev_nvme_start_discovery(struct spdk_nvme_transport_id *trid,
 	struct discovery_ctx *ctx;
 	struct discovery_entry_ctx *discovery_entry_ctx;
 
+	SPDK_ERRLOG("PARAMLOG FIRST: trid: %p ctx->name: %s trid->traddr: %s trid->trsvcid: %s trid->adrfam %d trid->trtype %d\n", trid, base_name, trid->traddr, trid->trsvcid, trid->adrfam, trid->trtype);
 	snprintf(trid->subnqn, sizeof(trid->subnqn), "%s", SPDK_NVMF_DISCOVERY_NQN);
 	TAILQ_FOREACH(ctx, &g_discovery_ctxs, tailq) {
 		if (strcmp(ctx->name, base_name) == 0) {
@@ -5576,6 +5577,7 @@ bdev_nvme_start_discovery(struct spdk_nvme_transport_id *trid,
 	TAILQ_INIT(&ctx->nvm_entry_ctxs);
 	TAILQ_INIT(&ctx->discovery_entry_ctxs);
 	memcpy(&ctx->trid, trid, sizeof(*trid));
+	DISCOVERY_ERRLOG(ctx, "PARAMLOG SECOND: trid: %p ctx->name: %s trid->traddr: %s trid->trsvcid: %s trid->adrfam %d trid->trtype %d\n", trid, ctx->name, trid->traddr, trid->trsvcid, trid->adrfam, trid->trtype);
 	/* Even if user did not specify hostnqn, we can still strdup("\0"); */
 	ctx->hostnqn = strdup(ctx->drv_opts.hostnqn);
 	if (ctx->hostnqn == NULL) {

--- a/module/bdev/nvme/bdev_nvme.c
+++ b/module/bdev/nvme/bdev_nvme.c
@@ -5241,7 +5241,6 @@ create_discovery_entry_ctx(struct discovery_ctx *ctx, struct spdk_nvme_transport
 	}
 	new_ctx->ctx = ctx;
 	memcpy(&new_ctx->trid, trid, sizeof(*trid));
-	DISCOVERY_ERRLOG(ctx, "PARAMLOG: trid: %p ctx->name: %s new_ctx->trid.traddr: %s new_ctx->trid.trsvcid: %s new_ctx->trid.adrfam %d new_ctx->trid.trtype %d\n", trid, ctx->name, new_ctx->trid.traddr, new_ctx->trid.trsvcid, new_ctx->trid.adrfam, new_ctx->trid.trtype);
 	spdk_nvme_ctrlr_get_default_ctrlr_opts(&new_ctx->drv_opts, sizeof(new_ctx->drv_opts));
 	snprintf(new_ctx->drv_opts.hostnqn, sizeof(new_ctx->drv_opts.hostnqn), "%s", ctx->hostnqn);
 	return new_ctx;
@@ -5527,7 +5526,6 @@ bdev_nvme_start_discovery(struct spdk_nvme_transport_id *trid,
 	struct discovery_ctx *ctx;
 	struct discovery_entry_ctx *discovery_entry_ctx;
 
-	SPDK_ERRLOG("PARAMLOG FIRST: trid: %p ctx->name: %s trid->traddr: %s trid->trsvcid: %s trid->adrfam %d trid->trtype %d\n", trid, base_name, trid->traddr, trid->trsvcid, trid->adrfam, trid->trtype);
 	snprintf(trid->subnqn, sizeof(trid->subnqn), "%s", SPDK_NVMF_DISCOVERY_NQN);
 	TAILQ_FOREACH(ctx, &g_discovery_ctxs, tailq) {
 		if (strcmp(ctx->name, base_name) == 0) {
@@ -5577,7 +5575,6 @@ bdev_nvme_start_discovery(struct spdk_nvme_transport_id *trid,
 	TAILQ_INIT(&ctx->nvm_entry_ctxs);
 	TAILQ_INIT(&ctx->discovery_entry_ctxs);
 	memcpy(&ctx->trid, trid, sizeof(*trid));
-	DISCOVERY_ERRLOG(ctx, "PARAMLOG SECOND: trid: %p ctx->name: %s trid->traddr: %s trid->trsvcid: %s trid->adrfam %d trid->trtype %d\n", trid, ctx->name, trid->traddr, trid->trsvcid, trid->adrfam, trid->trtype);
 	/* Even if user did not specify hostnqn, we can still strdup("\0"); */
 	ctx->hostnqn = strdup(ctx->drv_opts.hostnqn);
 	if (ctx->hostnqn == NULL) {

--- a/module/bdev/nvme/bdev_nvme.c
+++ b/module/bdev/nvme/bdev_nvme.c
@@ -5239,7 +5239,7 @@ create_discovery_entry_ctx(struct discovery_ctx *ctx, struct spdk_nvme_transport
 		DISCOVERY_ERRLOG(ctx, "could not allocate new entry_ctx\n");
 		return NULL;
 	}
-	
+
 	new_ctx->ctx = ctx;
 	memcpy(&new_ctx->trid, trid, sizeof(*trid));
 	spdk_nvme_ctrlr_get_default_ctrlr_opts(&new_ctx->drv_opts, sizeof(new_ctx->drv_opts));

--- a/module/bdev/nvme/bdev_nvme.c
+++ b/module/bdev/nvme/bdev_nvme.c
@@ -5239,6 +5239,7 @@ create_discovery_entry_ctx(struct discovery_ctx *ctx, struct spdk_nvme_transport
 		DISCOVERY_ERRLOG(ctx, "could not allocate new entry_ctx\n");
 		return NULL;
 	}
+	
 	new_ctx->ctx = ctx;
 	memcpy(&new_ctx->trid, trid, sizeof(*trid));
 	spdk_nvme_ctrlr_get_default_ctrlr_opts(&new_ctx->drv_opts, sizeof(new_ctx->drv_opts));

--- a/python/spdk/rpc/bdev.py
+++ b/python/spdk/rpc/bdev.py
@@ -1687,3 +1687,37 @@ def bdev_daos_resize(client, name, new_size):
             'new_size': new_size,
             }
     return client.call('bdev_daos_resize', params)
+
+def bdev_nvme_start_mdns_discovery(client, name, svcname, hostnqn=None):
+    """Start discovery with mDNS
+
+    Args:
+        name: bdev name prefix; "n" + unique seqno + namespace ID will be appended to create unique names
+        svcname: service to discover ("_nvme-disc._tcp")
+        traddr: transport address (PCI BDF or IP address)
+        adrfam: address family ("IPv4", "IPv6", "IB", or "FC")
+        trsvcid: transport service ID (port number for IP-based addresses)
+        hostnqn: NQN to connect from (optional)
+    """
+    params = {'name': name,
+              'svcname': svcname}
+
+    if hostnqn:
+        params['hostnqn'] = hostnqn
+    return client.call('bdev_nvme_start_mdns_discovery', params)
+
+def bdev_nvme_stop_mdns_discovery(client, name):
+    """Stop a previously started mdns discovery service
+
+    Args:
+        name: name of the discovery service to stop
+    """
+    params = {'name': name}
+
+    return client.call('bdev_nvme_stop_mdns_discovery', params)
+
+
+def bdev_nvme_get_mdns_discovery_info(client):
+    """Get information about the automatic mdns discovery
+    """
+    return client.call('bdev_nvme_get_mdns_discovery_info')

--- a/scripts/pkgdep.sh
+++ b/scripts/pkgdep.sh
@@ -19,6 +19,7 @@ function usage() {
 	echo "  -b --docs                   Additional dependencies for building docs"
 	echo "  -u --uring                  Additional dependencies for io_uring"
 	echo "  -D --daos                   Additional dependencies for DAOS"
+	cho "   -A --avahi                  Additional dependencies for AVAHI mDNS Discovery"
 	echo ""
 	exit 0
 }
@@ -32,6 +33,7 @@ function install_all_dependencies() {
 	INSTALL_DOCS=true
 	INSTALL_LIBURING=true
 	INSTALL_DAOS=true
+	INSTALL_AVAHI=true
 }
 
 INSTALL_CRYPTO=false
@@ -43,6 +45,7 @@ INSTALL_RDMA=false
 INSTALL_DOCS=false
 INSTALL_LIBURING=false
 INSTALL_DAOS=false
+INSTALL_AVAHI=false
 
 while getopts 'abdfhipruDR-:' optchar; do
 	case "$optchar" in
@@ -58,6 +61,7 @@ while getopts 'abdfhipruDR-:' optchar; do
 				docs) INSTALL_DOCS=true ;;
 				uring) INSTALL_LIBURING=true ;;
 				daos) INSTALL_DAOS=true ;;
+				avahi) INSTALL_AVAHI=true ;;
 				*)
 					echo "Invalid argument '$OPTARG'"
 					usage
@@ -74,6 +78,7 @@ while getopts 'abdfhipruDR-:' optchar; do
 		b) INSTALL_DOCS=true ;;
 		u) INSTALL_LIBURING=true ;;
 		D) INSTALL_DAOS=true ;;
+		A) INSTALL_AVAHI=true ;;
 		*)
 			echo "Invalid argument '$OPTARG'"
 			usage

--- a/scripts/pkgdep/debian.sh
+++ b/scripts/pkgdep/debian.sh
@@ -78,3 +78,8 @@ if [[ $INSTALL_DOCS == "true" ]]; then
 	# Additional dependencies for building docs
 	apt-get install -y doxygen mscgen graphviz
 fi
+# Additional dependencies for Avahi
+if [[ $INSTALL_AVAHI == "true" ]]; then
+	# Additional dependencies for AVAHI
+	apt-get install -y libavahi-client-dev
+fi

--- a/scripts/pkgdep/rhel.sh
+++ b/scripts/pkgdep/rhel.sh
@@ -178,3 +178,8 @@ if [[ $INSTALL_DAOS == "true" ]]; then
 		echo "Skipping installation of DAOS bdev dependencies. It is supported only for CentOS 7, CentOS 8 and Rocky 8"
 	fi
 fi
+# Additional dependencies for Avahi
+if [[ $INSTALL_AVAHI == "true" ]]; then
+	# Additional dependencies for AVAHI
+	yum install -y avahi-devel
+fi

--- a/scripts/pkgdep/sles.sh
+++ b/scripts/pkgdep/sles.sh
@@ -40,3 +40,7 @@ if [[ $INSTALL_DAOS == "true" ]]; then
 	zypper --non-interactive refresh
 	zypper install -y daos-client daos-devel
 fi
+if [[ $INSTALL_AVAHI == "true" ]]; then
+	# Additional dependencies for AVAHI
+	zypper install -y avahi-devel
+fi

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -3176,6 +3176,31 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('new_size', help='new bdev size for resize operation. The unit is MiB')
     p.set_defaults(func=bdev_daos_resize)
 
+    def bdev_nvme_start_mdns_discovery(args):
+        rpc.bdev.bdev_nvme_start_mdns_discovery(args.client,
+                                           name=args.name,
+                                           svcname=args.svcname,
+                                           hostnqn=args.hostnqn)
+
+    p = subparsers.add_parser('bdev_nvme_start_mdns_discovery', help='Start mdns based automatic discovery')
+    p.add_argument('-b', '--name', help="Name of the NVMe controller prefix for each bdev name", required=True)
+    p.add_argument('-s', '--svcname', help='Service type to discover: e.g., _nvme-disc._tcp', required=True)
+    p.add_argument('-q', '--hostnqn', help='NVMe-oF host subnqn')
+    p.set_defaults(func=bdev_nvme_start_mdns_discovery)
+
+    def bdev_nvme_stop_mdns_discovery(args):
+        rpc.bdev.bdev_nvme_stop_mdns_discovery(args.client, name=args.name)
+
+    p = subparsers.add_parser('bdev_nvme_stop_mdns_discovery', help='Stop automatic mdns discovery')
+    p.add_argument('-b', '--name', help="Name of the service to stop", required=True)
+    p.set_defaults(func=bdev_nvme_stop_mdns_discovery)
+
+    def bdev_nvme_get_mdns_discovery_info(args):
+        print_dict(rpc.bdev.bdev_nvme_get_mdns_discovery_info(args.client))
+
+    p = subparsers.add_parser('bdev_nvme_get_mdns_discovery_info', help='Get information about the automatic mdns discovery')
+    p.set_defaults(func=bdev_nvme_get_mdns_discovery_info)
+
     def check_called_name(name):
         if name in deprecated_aliases:
             print("{} is deprecated, use {} instead.".format(name, deprecated_aliases[name]), file=sys.stderr)


### PR DESCRIPTION
Feature implemented:
This code change implements TP-8009 Auto-discovery of Discovery controllers for NVME initiator using mDNS using Avahi.

Approach:
Avahi Daemon needs to be running to provide the mDNS server service. In the SPDK, Avahi-client library based client API is implemented.
The client API will connect to the Avahi-daemon and receive events for new discovery and removal of an existing discovery entry.

Following sets on new RPCs have been introduced.
1. scripts/rpc.py bdev_nvme_start_mdns_discovery -b cdc_auto -s _nvme-disc._tcp
User shall initiate an mDNS based discovery using this RPC. This will start a Avahi-client based poller
looking for new discovery events from the Avahi server. On a new discovery of the discovery controller,
the existing bdev_nvme_start_discovery API will be invoked with the trid of the discovery controller learnt.
This will enable automatic connection of the initiator to the subsystems discovered from the discovery controller.
Multiple mdns discovery instances can be run by specifying a unique bdev-prefix and a unique servicename to discover as parameters.

2. scripts/rpc.py bdev_nvme_stop_mdns_discovery -b cdc_auto
This will stop the Avahi poller that was started for the specified service.Internally bdev_nvme_stop_discovery
API will be invoked for each of the discovery controllers learnt automatically by this instance of mdns discovery service.
This will result in termination of connections to all the subsystems learnt by this mdns discovery instance.

3. scripts/rpc.py bdev_nvme_get_mdns_discovery_info
This RPC will display the list of mdns discovery instances running and the trid of the controllers discovered by these instances.

Test results
=============

root@ubuntu-pm-18-226:~/param-spdk/spdk/build/bin# ./nvmf_tgt -i 1 -s 2048 -m 0xF
root@ubuntu-pm-18-226:~/param-spdk/spdk# scripts/rpc.py bdev_nvme_start_mdns_discovery -b cdc_auto -s _nvme-disc._tcp
root@ubuntu-pm-18-226:~/param-spdk/spdk#
root@ubuntu-pm-18-226:~/param-spdk/spdk# scripts/rpc.py bdev_nvme_get_mdns_discovery_info
[
  {
    "name": "cdc_auto",
    "svcname": "_nvme-disc._tcp",
    "referrals": [
      {
        "name": "cdc_auto0",
        "trid": {
          "trtype": "TCP",
          "adrfam": "IPv4",
          "traddr": "66.1.2.21",
          "trsvcid": "8009",
          "subnqn": "nqn.2014-08.org.nvmexpress.discovery"
        }
      },
      {
        "name": "cdc_auto1",
        "trid": {
          "trtype": "TCP",
          "adrfam": "IPv4",
          "traddr": "66.1.1.21",
          "trsvcid": "8009",
          "subnqn": "nqn.2014-08.org.nvmexpress.discovery"
        }
      }
    ]
  }
]
root@ubuntu-pm-18-226:~/param-spdk/spdk#
root@ubuntu-pm-18-226:~/param-spdk/spdk# scripts/rpc.py bdev_nvme_get_discovery_info
[
  {
    "name": "cdc_auto0",
    "trid": {
      "trtype": "TCP",
      "adrfam": "IPv4",
      "traddr": "66.1.2.21",
      "trsvcid": "8009",
      "subnqn": "nqn.2014-08.org.nvmexpress.discovery"
    },
    "referrals": []
  },
  {
    "name": "cdc_auto1",
    "trid": {
      "trtype": "TCP",
      "adrfam": "IPv4",
      "traddr": "66.1.1.21",
      "trsvcid": "8009",
      "subnqn": "nqn.2014-08.org.nvmexpress.discovery"
    },
    "referrals": []
  }
]
root@ubuntu-pm-18-226:~/param-spdk/spdk# scripts/rpc.py bdev_get_bdevs
[
  {
    "name": "cdc_auto02n1",
    "aliases": [
      "600110d6-1681-1681-0403-000045805c45"
    ],
    "product_name": "NVMe disk",
    "block_size": 512,
    "num_blocks": 32768,
    "uuid": "600110d6-1681-1681-0403-000045805c45",
    "assigned_rate_limits": {
      "rw_ios_per_sec": 0,
      "rw_mbytes_per_sec": 0,
      "r_mbytes_per_sec": 0,
      "w_mbytes_per_sec": 0
    },
    "claimed": false,
    "zoned": false,
    "supported_io_types": {
      "read": true,
      "write": true,
      "unmap": true,
      "write_zeroes": true,
      "flush": true,
      "reset": true,
      "compare": true,
      "compare_and_write": true,
      "abort": true,
      "nvme_admin": true,
      "nvme_io": true
    },
    "driver_specific": {
      "nvme": [
        {
          "trid": {
            "trtype": "TCP",
            "adrfam": "IPv4",
            "traddr": "66.1.1.40",
            "trsvcid": "4420",
            "subnqn": "nqn.2014-08.com.sanblaze:virtualun.virtualun.3.0"
          },
          "ctrlr_data": {
            "cntlid": 3,
            "vendor_id": "0x0000",
            "model_number": "SANBlaze VLUN P3T0",
            "serial_number": "00-681681dc681681dc",
            "firmware_revision": "V10.5",
            "subnqn": "nqn.2014-08.com.sanblaze:virtualun.virtualun.3.0",
            "oacs": {
              "security": 0,
              "format": 1,
              "firmware": 0,
              "ns_manage": 1
            },
            "multi_ctrlr": true,
            "ana_reporting": true
          },
          "vs": {
            "nvme_version": "2.0"
          },
          "ns_data": {
            "id": 1,
            "ana_state": "optimized",
            "can_share": true
          }
        }
      ],
      "mp_policy": "active_passive"
    }
  },
  {
    "name": "cdc_auto00n1",
    "aliases": [
      "600110da-09a6-09a6-0302-00005eeb19b4"
    ],
    "product_name": "NVMe disk",
    "block_size": 512,
    "num_blocks": 2048,
    "uuid": "600110da-09a6-09a6-0302-00005eeb19b4",
    "assigned_rate_limits": {
      "rw_ios_per_sec": 0,
      "rw_mbytes_per_sec": 0,
      "r_mbytes_per_sec": 0,
      "w_mbytes_per_sec": 0
    },
    "claimed": false,
    "zoned": false,
    "supported_io_types": {
      "read": true,
      "write": true,
      "unmap": true,
      "write_zeroes": true,
      "flush": true,
      "reset": true,
      "compare": true,
      "compare_and_write": true,
      "abort": true,
      "nvme_admin": true,
      "nvme_io": true
    },
    "driver_specific": {
      "nvme": [
        {
          "trid": {
            "trtype": "TCP",
            "adrfam": "IPv4",
            "traddr": "66.1.2.40",
            "trsvcid": "4420",
            "subnqn": "nqn.2014-08.com.sanblaze:virtualun.virtualun.2.0"
          },
          "ctrlr_data": {
            "cntlid": 1,
            "vendor_id": "0x0000",
            "model_number": "SANBlaze VLUN P2T0",
            "serial_number": "00-ab09a6f5ab09a6f5",
            "firmware_revision": "V10.5",
            "subnqn": "nqn.2014-08.com.sanblaze:virtualun.virtualun.2.0",
            "oacs": {
              "security": 0,
              "format": 1,
              "firmware": 0,
              "ns_manage": 1
            },
            "multi_ctrlr": true,
            "ana_reporting": true
          },
          "vs": {
            "nvme_version": "2.0"
          },
          "ns_data": {
            "id": 1,
            "ana_state": "optimized",
            "can_share": true
          }
        }
      ],
      "mp_policy": "active_passive"
    }
  },
  {
    "name": "cdc_auto01n1",
    "aliases": [
      "600110d6-dce8-dce8-0403-00010b2d3d8c"
    ],
    "product_name": "NVMe disk",
    "block_size": 512,
    "num_blocks": 32768,
    "uuid": "600110d6-dce8-dce8-0403-00010b2d3d8c",
    "assigned_rate_limits": {
      "rw_ios_per_sec": 0,
      "rw_mbytes_per_sec": 0,
      "r_mbytes_per_sec": 0,
      "w_mbytes_per_sec": 0
    },
    "claimed": false,
    "zoned": false,
    "supported_io_types": {
      "read": true,
      "write": true,
      "unmap": true,
      "write_zeroes": true,
      "flush": true,
      "reset": true,
      "compare": true,
      "compare_and_write": true,
      "abort": true,
      "nvme_admin": true,
      "nvme_io": true
    },
    "driver_specific": {
      "nvme": [
        {
          "trid": {
            "trtype": "TCP",
            "adrfam": "IPv4",
            "traddr": "66.1.1.40",
            "trsvcid": "4420",
            "subnqn": "nqn.2014-08.com.sanblaze:virtualun.virtualun.3.1"
          },
          "ctrlr_data": {
            "cntlid": 3,
            "vendor_id": "0x0000",
            "model_number": "SANBlaze VLUN P3T1",
            "serial_number": "01-6ddce86d6ddce86d",
            "firmware_revision": "V10.5",
            "subnqn": "nqn.2014-08.com.sanblaze:virtualun.virtualun.3.1",
            "oacs": {
              "security": 0,
              "format": 1,
              "firmware": 0,
              "ns_manage": 1
            },
            "multi_ctrlr": true,
            "ana_reporting": true
          },
          "vs": {
            "nvme_version": "2.0"
          },
          "ns_data": {
            "id": 1,
            "ana_state": "optimized",
            "can_share": true
          }
        }
      ],
      "mp_policy": "active_passive"
    }
  },
  {
    "name": "cdc_auto01n2",
    "aliases": [
      "600110d6-dce8-dce8-0403-00010b2d3d8d"
    ],
    "product_name": "NVMe disk",
    "block_size": 512,
    "num_blocks": 32768,
    "uuid": "600110d6-dce8-dce8-0403-00010b2d3d8d",
    "assigned_rate_limits": {
      "rw_ios_per_sec": 0,
      "rw_mbytes_per_sec": 0,
      "r_mbytes_per_sec": 0,
      "w_mbytes_per_sec": 0
    },
    "claimed": false,
    "zoned": false,
    "supported_io_types": {
      "read": true,
      "write": true,
      "unmap": true,
      "write_zeroes": true,
      "flush": true,
      "reset": true,
      "compare": true,
      "compare_and_write": true,
      "abort": true,
      "nvme_admin": true,
      "nvme_io": true
    },
    "driver_specific": {
      "nvme": [
        {
          "trid": {
            "trtype": "TCP",
            "adrfam": "IPv4",
            "traddr": "66.1.1.40",
            "trsvcid": "4420",
            "subnqn": "nqn.2014-08.com.sanblaze:virtualun.virtualun.3.1"
          },
          "ctrlr_data": {
            "cntlid": 3,
            "vendor_id": "0x0000",
            "model_number": "SANBlaze VLUN P3T1",
            "serial_number": "01-6ddce86d6ddce86d",
            "firmware_revision": "V10.5",
            "subnqn": "nqn.2014-08.com.sanblaze:virtualun.virtualun.3.1",
            "oacs": {
              "security": 0,
              "format": 1,
              "firmware": 0,
              "ns_manage": 1
            },
            "multi_ctrlr": true,
            "ana_reporting": true
          },
          "vs": {
            "nvme_version": "2.0"
          },
          "ns_data": {
            "id": 2,
            "ana_state": "optimized",
            "can_share": true
          }
        }
      ],
      "mp_policy": "active_passive"
    }
  }
]
root@ubuntu-pm-18-226:~/param-spdk/spdk#

root@ubuntu-pm-18-226:~/param-spdk/spdk# scripts/rpc.py bdev_nvme_stop_mdns_discovery -b cdc_auto
root@ubuntu-pm-18-226:~/param-spdk/spdk#
root@ubuntu-pm-18-226:~/param-spdk/spdk# scripts/rpc.py bdev_nvme_get_mdns_discovery_info
[]
root@ubuntu-pm-18-226:~/param-spdk/spdk# scripts/rpc.py bdev_nvme_get_discovery_info
[]
root@ubuntu-pm-18-226:~/param-spdk/spdk# scripts/rpc.py bdev_get_bdevs
[]
root@ubuntu-pm-18-226:~/param-spdk/spdk#


