### PR TITLE
doc/nvmf_tgt_pg: Update broken link to NVMe specifications

### DIFF
--- a/doc/nvmf_tgt_pg.md
+++ b/doc/nvmf_tgt_pg.md
@@ -17,7 +17,7 @@ used in the implementation of the example NVMe-oF target application in
 
 This guide is written assuming that the reader is familiar with both NVMe and
 NVMe over Fabrics. The best way to become familiar with those is to read their
-[specifications](http://nvmexpress.org/resources/specifications/).
+[specifications](https://nvmexpress.org/specifications/).
 
 ## Primitives
 


### PR DESCRIPTION
The link to NVMe specification was no longer up to date. Replace it with working link.