### PR TITLE
scripts: remove the invalid option -n for local.

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -314,7 +314,7 @@ function collect_devices() {
 			fi
 		fi
 		# Update in-use for each bdf. Default from the map_supported_devices() is 0 == "not used"
-		local -n type_ref=${all_devices_type_d["$bdf"]}_d
+		local type_ref=${all_devices_type_d["$bdf"]}_d
 		type_ref["$bdf"]=$in_use
 		all_devices_d["$bdf"]=$in_use
 	done


### PR DESCRIPTION
## Sighting report
The option `-n` is invalid for local at setup.sh

## Expected Behavior

Correctly setup like below output:

```
000:80:01.3 (8086 0b00): no driver -> uio_pci_generic
0000:80:01.2 (8086 0b00): no driver -> uio_pci_generic
0000:80:01.1 (8086 0b00): no driver -> uio_pci_generic
0000:80:01.0 (8086 0b00): no driver -> uio_pci_generic
0000:80:01.7 (8086 0b00): no driver -> uio_pci_generic
0000:80:01.6 (8086 0b00): no driver -> uio_pci_generic
0000:80:01.5 (8086 0b00): no driver -> uio_pci_generic
0000:80:01.4 (8086 0b00): no driver -> uio_pci_generic
0000:00:01.3 (8086 0b00): no driver -> uio_pci_generic
0000:00:01.2 (8086 0b00): no driver -> uio_pci_generic
0000:00:01.1 (8086 0b00): no driver -> uio_pci_generic
0000:00:01.0 (8086 0b00): no driver -> uio_pci_generic
0000:00:01.7 (8086 0b00): no driver -> uio_pci_generic
0000:00:01.6 (8086 0b00): no driver -> uio_pci_generic
0000:00:01.5 (8086 0b00): no driver -> uio_pci_generic
0000:00:01.4 (8086 0b00): no driver -> uio_pci_generic
0000:e4:00.0 (8086 0b60): nvme -> uio_pci_generic
0000:e5:00.0 (8086 0b60): nvme -> uio_pci_generic
0000:65:00.0 (8086 0b60): nvme -> uio_pci_generic
0000:66:00.0 (8086 0b60): nvme -> uio_pci_generic
0000:4d:00.0 (8086 0b60): nvme -> uio_pci_generic
0000:68:00.0 (8086 0b60): nvme -> uio_pci_generic
0000:4e:00.0 (8086 0b60): nvme -> uio_pci_generic
0000:4c:00.0 (8086 0b60): nvme -> uio_pci_generic
0000:e3:00.0 (8086 0b60): nvme -> uio_pci_generic
0000:67:00.0 (8086 0b60): nvme -> uio_pci_generic
0000:e6:00.0 (8086 0b60): nvme -> uio_pci_generic
0000:4b:00.0 (8086 0b60): nvme -> uio_pci_generic
```

## Current Behavior

Have some output logs like below:

```
0000:4c:00.0 (8086 0b60): Active devices: mount@nvme1n1:nvme1n1, so not binding PCI dev
./setup.sh: line 317: local: -n: invalid option
local: usage: local [option] name[=value] ...
```

## Possible Solution
remove -n option which is behind the local key word.