### PR TITLE
configure: don't exit when configure idxd on non Intel platforms

### DIFF
--- a/configure
+++ b/configure
@@ -706,8 +706,7 @@ if [[ "${CONFIG[IDXD]}" = "y" ]]; then
 		cpu_vendor=$(grep -i 'vendor' /proc/cpuinfo --max-count=1)
 	fi
 	if [[ "$cpu_vendor" != *"$intel"* ]]; then
-		echo "ERROR: IDXD cannot be used due to CPU incompatibility."
-		exit 1
+		echo "WARNING: IDXD cannot be used due to CPU incompatibility."
 	fi
 	if [ -e /usr/include/accel-config/libaccel_config.h ]; then
 		CONFIG[IDXD_KERNEL]=y


### PR DESCRIPTION
In order to better promote DSA to users, it is recommended to change the error message detected by non Intel CPUs to warning. Users may compile spdk in docker images with idxd on different platforms, and then use docker "pull" and "run". But this error affects the convenient use of DSA. The check here is too strict, and users must modify the code and configure for different platforms. Although DSA hardware is not available on non Intel platforms and some lower versions of Intel CPUs, configuring it is code safe. Because the order of sending instructions is after checking the DSA hardware.