### PR TITLE
fix incorrect assert of uring tracker buf len, and fill zero when add

### DIFF
--- a/module/sock/uring/uring.c
+++ b/module/sock/uring/uring.c
@@ -881,6 +881,8 @@ uring_sock_recv_next(struct spdk_sock *_sock, void **_buf, void **ctx)
 
 	*_buf = tr->buf + sock->recv_offset;
 	*ctx = tr->ctx;
+    size_t tr_len = tr->len;
+    tr->len = 0;
 
 	STAILQ_REMOVE_HEAD(&sock->recv_stream, link);
 	STAILQ_INSERT_HEAD(&group->free_trackers, tr, link);
@@ -890,7 +892,7 @@ uring_sock_recv_next(struct spdk_sock *_sock, void **_buf, void **ctx)
 		TAILQ_REMOVE(&group->pending_recv, sock, link);
 	}
 
-	return tr->len - sock->recv_offset;
+	return tr_len - sock->recv_offset;
 }
 
 static ssize_t
@@ -947,6 +949,7 @@ uring_sock_readv_no_pipe(struct spdk_sock *_sock, struct iovec *iovs, int iovcnt
 			if (sock->recv_offset == tr->len) {
 				sock->recv_offset = 0;
 				STAILQ_REMOVE_HEAD(&sock->recv_stream, link);
+                tr->len = 0;
 				STAILQ_INSERT_HEAD(&sock->group->free_trackers, tr, link);
 				spdk_sock_group_provide_buf(sock->group->base.group, tr->buf, tr->buflen, tr->ctx);
 				tr = STAILQ_FIRST(&sock->recv_stream);
@@ -1384,7 +1387,7 @@ sock_uring_group_reap(struct spdk_uring_sock_group_impl *group, int max, int max
 				tracker = &group->trackers[bid];
 
 				assert(tracker->buf != NULL);
-				assert(tracker->len != 0);
+				assert(tracker->len == 0);
 
 				/* Append this data to the stream */
 				tracker->len = status;

--- a/module/sock/uring/uring.c
+++ b/module/sock/uring/uring.c
@@ -881,8 +881,8 @@ uring_sock_recv_next(struct spdk_sock *_sock, void **_buf, void **ctx)
 
 	*_buf = tr->buf + sock->recv_offset;
 	*ctx = tr->ctx;
-    size_t tr_len = tr->len;
-    tr->len = 0;
+	size_t tr_len = tr->len;
+	tr->len = 0;
 
 	STAILQ_REMOVE_HEAD(&sock->recv_stream, link);
 	STAILQ_INSERT_HEAD(&group->free_trackers, tr, link);
@@ -949,7 +949,7 @@ uring_sock_readv_no_pipe(struct spdk_sock *_sock, struct iovec *iovs, int iovcnt
 			if (sock->recv_offset == tr->len) {
 				sock->recv_offset = 0;
 				STAILQ_REMOVE_HEAD(&sock->recv_stream, link);
-                tr->len = 0;
+				tr->len = 0;
 				STAILQ_INSERT_HEAD(&sock->group->free_trackers, tr, link);
 				spdk_sock_group_provide_buf(sock->group->base.group, tr->buf, tr->buflen, tr->ctx);
 				tr = STAILQ_FIRST(&sock->recv_stream);


### PR DESCRIPTION
1.  member 'len' of struct 'spdk_uring_buf_tracker' should be reset to '0' when a 'tr/tracker' is return back to 'group->free_trackers'
2.  in routine 'sock_uring_group_reap',  when a tracker is picked up, 'assert(tracker->len != 0);'  should be 'assert(tracker->len == 0);'  as the len is not initialized. 

