### PR TITLE
spdkcli: import missing json module

### DIFF
--- a/python/spdk/spdkcli/ui_node_nvmf.py
+++ b/python/spdk/spdkcli/ui_node_nvmf.py
@@ -4,6 +4,7 @@
 
 from ..rpc.client import JSONRPCException
 from .ui_node import UINode
+import json
 
 
 class UINVMf(UINode):


### PR DESCRIPTION
# PR Summary
The `ui_node_nvmf.py` file is missing an import of the `json` module. This module is being used on line [144](https://github.com/emmanuel-ferdman/spdk/blob/f747c38ac1487d9d50475b5ac064254ac435e1ee/python/spdk/spdkcli/ui_node_nvmf.py#L144).