### PR TITLE
Port of CI/CD from spdk-community-ci (v2)

### DIFF
--- a/.github/workflows/autorun.yml
+++ b/.github/workflows/autorun.yml
@@ -1,0 +1,107 @@
+name: autorun
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch with changes e.g. "changes/xx/yyyyyy/zz"'
+        required: true
+        default: 'master'
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+    branches: [master]
+
+jobs:
+  source-archive:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/refenv/cijoe-docker:v0.9.47
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.1.7
+        with:
+          submodules: 'recursive'
+          fetch-depth: 0
+
+      - name: Create a tarball of the repository
+        run: |
+          tar -czf /tmp/repository.tar.gz .
+
+      - name: Upload the repository as an artifact
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: repository
+          path: /tmp/repository.tar.gz
+
+  autorun:
+    runs-on: ubuntu-latest
+    needs: source-archive
+    timeout-minutes: 35
+    env:
+      REPOSITORY_TARBALL_PATH: ${{ github.workspace }}/repository.tar.gz
+    strategy:
+      matrix:
+        workflow: [autorun_unittest, autorun_nvme]
+    container:
+      image: ghcr.io/refenv/cijoe-docker:v0.9.47
+      options: --privileged
+
+    steps:
+      - name: Setup PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Download the SPDK repository
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: repository
+
+      - name: Extract the SPDK repository
+        run: |
+          tar xzf repository.tar.gz --strip 1
+
+      - name: qemu-guest, provision
+        run: |
+          cd scripts/cijoe
+          cijoe guest_initialize guest_start guest_check tgz_transfer tgz_unpack \
+          --monitor \
+          --config configs/qemuhost-with-guest-fedora-40.toml \
+          --workflow workflows/autorun_in_qemu.yaml \
+          --output report_${{ matrix.workflow }}_prep_guest
+
+      - name: qemu-guest, ${{ matrix.workflow }}
+        run: |
+          cd scripts/cijoe
+          cijoe ${{ matrix.workflow }} \
+          --monitor \
+          --config configs/qemuhost-with-guest-fedora-40.toml \
+          --workflow workflows/autorun_in_qemu.yaml \
+          --output report_${{ matrix.workflow }}
+
+      - name: qemu-guest, cleanup
+        if: always()
+        run: |
+          cd scripts/cijoe
+          cijoe output_listing retrieve_autorun_output guest_shutdown \
+          --monitor \
+          --config configs/qemuhost-with-guest-fedora-40.toml \
+          --workflow workflows/autorun_in_qemu.yaml \
+          --output report_${{ matrix.workflow }}_cleanup
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4.4.0
+        if: always()
+        with:
+          path: /tmp/autorun_output
+          name: ${{ matrix.workflow }}_artifacts
+
+      - name: Upload Report
+        uses: actions/upload-artifact@v4.4.0
+        if: always()
+        with:
+          path: |
+            scripts/cijoe/report_${{ matrix.workflow }}
+            scripts/cijoe/report_${{ matrix.workflow }}_cleanup
+            scripts/cijoe/report_${{ matrix.workflow }}_prep_guest
+          name: report-${{ matrix.workflow }}-in-qemu

--- a/.github/workflows/build_qcow2.yml
+++ b/.github/workflows/build_qcow2.yml
@@ -1,0 +1,124 @@
+---
+name: build_qcow2
+
+on:
+  workflow_dispatch:
+    inputs:
+      spdk_repos_ref:
+        description: 'Branch, tag, or ref of SPDK repository'
+        required: true
+        default: 'master'
+
+jobs:
+
+  source-archive:
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: build_qcow2
+      cancel-in-progress: false
+
+    steps:
+    - name: Checkout SPDK repository
+      uses: actions/checkout@v4.1.7
+      with:
+        repository: ${{ github.repository_owner }}/${{ vars.SPDK_REPOS_NAME }}
+        ref: ${{ github.event.inputs.spdk_repos_ref }}
+        token: ${{ secrets.GHPA_TOKEN }}
+        submodules: 'recursive'
+        fetch-depth: 0
+        path: spdk
+
+    - name: Add Information on the SPDK repository state
+      run: |
+        cd spdk
+        CURRENT_REF=$(git rev-parse --short HEAD)  # Gets the short commit hash as the ref
+        REPO_URL="https://github.com/${{ github.repository_owner }}/${{ vars.SPDK_REPOS_NAME }}/commit/$CURRENT_REF"
+        echo "### Change Information" >> $GITHUB_STEP_SUMMARY
+        echo "- Using pkgdeb.sh and autotest_setup.sh from [SPDK Repository]($REPO_URL)" >> $GITHUB_STEP_SUMMARY
+        echo "- Ref: $CURRENT_REF" >> $GITHUB_STEP_SUMMARY
+
+    - name: Create a tarball, of the repository, to preserve file permissions
+      run: |
+        cd spdk
+        tar -czf ../repository.tar.gz .
+
+    - name: Upload the repository as an artifact
+      uses: actions/upload-artifact@v4.4.0
+      with:
+        name: repository
+        path: repository.tar.gz
+
+  build-qcow:
+    needs: source-archive
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/spdk-community-ci/spdk-community-ci:poc
+      options: --privileged
+
+    env:
+      REPOSITORY_TARBALL_PATH: ${{ github.workspace }}/repository.tar.gz
+
+    concurrency:
+      group: build_qcow2
+      cancel-in-progress: false
+  
+    steps:
+    - name: Download the repository
+      uses: actions/download-artifact@v4.1.8
+      with:
+        name: repository
+      
+    - name: Checkout CI repository
+      uses: actions/checkout@v4.1.7
+      with:
+        path: ci
+
+    - name: Setup CIJOE and pipx
+      run: |
+        pipx install cijoe==0.9.45 -f
+        pipx ensurepath
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Build
+      run: |
+        cd ci/cijoe
+        cijoe \
+        --monitor \
+        --config configs/qemuhost-with-guest-fedora-40.toml \
+        --workflow workflows/build_qcow2_using_qemu.yaml
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4.4.0
+      if: always()
+      with:
+        path: ci/cijoe/cijoe-output
+        name: cloudinit-report
+
+    - name: Set up SSH
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.SSH_STORAGE_PRIVATE_KEY }}" > $HOME/.ssh/id_storage
+        echo "${{ secrets.SSH_STORAGE_KNOWN_HOSTS }}" >> $HOME/.ssh/known_hosts
+        chmod 600 ~/.ssh/id_storage
+
+    - name: Change image format and compress
+      run: |
+        ls -lha $HOME/guests/fedora_40_x86_64/
+        for i in $(seq 1 60); do test -f "$HOME/guests/fedora_40_x86_64/guest.pid" || break; sleep 1; done
+        ls -lha $HOME/guests/fedora_40_x86_64/
+        qemu-img convert $HOME/guests/fedora_40_x86_64/boot.img fedora_40_x86_64.qcow2 -O qcow2 -c
+        ls -lha fedora_40_x86_64.qcow2
+
+    # This relies on the following secrets: S3_KEY, S3_SECRET, S3_ENDPOINT_URL
+    - name: Transfer to S3 Compatible Storage
+      env:
+        S3_KEY: ${{ secrets.S3_KEY }}
+        S3_SECRET: ${{ secrets.S3_SECRET }}
+        S3_ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}
+        S3_BUCKET: spdk-community-ci
+      run : |
+        ./ci/s3_file_upload.py fedora_40_x86_64.qcow2 \
+        --bucket "$S3_BUCKET" \
+        --endpoint-url "$S3_ENDPOINT_URL" \
+        --object-key "system/fedora_40_x86_64.qcow2"

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,34 @@
+name: maintenance_selfhosted
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  maintenance:
+    strategy:
+      matrix:
+        runner:
+        - eqnx_qemuhost00
+        - eqnx_qemuhost01
+        - eqnx_qemuhost02
+        - eqnx_qemuhost03
+        - eqnx_qemuhost04
+
+    runs-on: ${{ matrix.runner }}
+
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/spdk-community-ci:poc
+      options: --privileged
+
+    steps:
+      - name: Get Runner Name
+        run: |
+          echo "This is running on runner ${{ runner.name }}"
+
+      - name: Remove qcow images
+        run: |
+          ls $HOME
+          ls $HOME/images
+          ls $HOME/
+          rm -rf $HOME/images

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -1,0 +1,27 @@
+---
+name: ci_selftest
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Format
+      run: |
+        pipx run -q --python python3 pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+---
+default_language_version:
+  python: python3
+
+repos:
+
+- repo: https://github.com/psf/black
+  rev: 24.10.0
+  hooks:
+  - id: black
+    name: Python-format-black
+    args: ["--line-length=88"]
+
+- repo: https://github.com/pycqa/isort
+  rev: 5.13.2
+  hooks:
+  - id: isort
+    name: Python-format-isort
+    args:
+    - '--profile=black'
+    - '--line-length=88'
+
+- repo: https://github.com/pycqa/flake8
+  rev: 7.1.1
+  hooks:
+  - id: flake8
+    name: Python-lint-flake8
+    # Max-line-length matching black
+    # ignore "whitespace before ':'"; ignore line length
+    # F401 = F811; This happens for fixtures for indirect parametrize
+    args:
+    - --max-line-length=88
+    - --extend-ignore=E203,F401,F811,E231,F541,E702
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.11.2
+  hooks:
+  - id: mypy
+    args: ["--ignore-missing-imports"]
+    additional_dependencies:
+    - types-requests

--- a/scripts/cijoe/.gitignore
+++ b/scripts/cijoe/.gitignore
@@ -1,0 +1,2 @@
+*cijoe-archive*
+*cijoe-output*

--- a/scripts/cijoe/configs/qemuhost-with-guest-fedora-40.toml
+++ b/scripts/cijoe/configs/qemuhost-with-guest-fedora-40.toml
@@ -1,0 +1,78 @@
+##
+## qemu-guest
+##
+
+# The SSH options are passed verbatim to paramiko; see https://www.paramiko.org/
+[cijoe.transport.ssh]
+username = "root"
+password = "root"
+hostname = "localhost"
+port = 4200
+
+[os]
+name = "fedora"
+version = "40"
+
+##
+## qemu-host
+## 
+
+[qemu]
+img_bin = "qemu-img"
+
+[qemu.systems.x86_64]
+bin = "qemu-system-x86_64"
+
+[qemu.systems.aarch64]
+bin = "qemu-system-aarch64"
+
+# Used by: qemu.guest_initialize.py, qemu.guest_start.py, and qemu.guest_kill.py
+[qemu.guests.generic-bios-kvm-x86_64]
+path = "{{ local.env.HOME }}/guests/generic-bios-kvm-x86_64"
+
+# Label of the qemu-system emulerator to use; see "qemu.systems"
+system_label = "x86_64"
+
+# Name of the system_image to use; see "system_imaging.images"
+# Uncomment here, or set as workflow-argument when using "qemu.guest_initialize"
+system_image_name = "fedora-40-x86_64"
+
+# Keyword arguments: joined onto the form: "-cpu host -smp 4 -m 4" etc.
+system_args.kwa = {cpu = "host", smp = 8, m = "12G", accel = "kvm"}
+
+# Raw arguments: passed without modification to qemu-system-{arch}
+system_args.raw = """\
+-M "type=q35,kernel_irqchip=split" \
+-device "intel-iommu,pt=on,intremap=on" \
+"""
+
+# TCP_FORWARD: Setup ssh forward from host to guest
+#
+# This is is a "special" argument, managed by the cijoe qemu-wrapper,
+# specifically by 'guest.start_guest()'
+system_args.tcp_forward = {host = 4200, guest = 22}
+
+# HOST_SHARE: Sares the given folder with the guest via 9p
+#
+# The configuration example, below shares your home folder, if you do not want
+# this, then comment it out
+#
+# This is is a "special" argument, managed by the cijoe qemu-wrapper,
+# specifically by 'guest.start_guest()'
+#system_args.host_share = "{{ local.env.HOME }}"
+
+# for system_imaging
+[system-imaging.images.fedora-40-x86_64]
+system_label = "x86_64"
+
+cloud.url ="https://mirrors.dotsrc.org/fedora-enchilada/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2"
+cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/Fedora-Cloud-Base-Generic-40-1.14.x86_64.qcow2"
+cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
+cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"
+
+disk.url = "https://spdk-community-ci.s3.eu-central-003.backblazeb2.com/system/fedora_40_x86_64.qcow2"
+disk.path = "{{ local.env.HOME }}/system_imaging/disk/fedora_40_x86_64.qcow2"
+
+docker.url = "ghcr.io/safl/fedora-40-x86_64:poc"
+docker.name = "spdk-ci-fedora-40-x86_64"
+docker.tag = "poc"

--- a/scripts/cijoe/scripts/guest_initialize.py
+++ b/scripts/cijoe/scripts/guest_initialize.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Guest initialization
+====================
+
+This script initializes a guest environment by setting up the necessary resources 
+for guest-instance management. It creates a directory structure to store files 
+related to the guest, such as:
+
+- PID files
+- Monitor files
+- Serial input/output logs
+- Other instance-specific metadata
+
+Additionally, the script prepares guest storage, including the boot drive, 
+using an existing `.qcow2` image (e.g., created via Cloud-init, Packer, etc.).
+
+Retargetable: False
+-------------------
+"""
+import errno
+import logging as log
+from pathlib import Path
+
+from cijoe.core.misc import download, download_and_verify
+from cijoe.qemu.wrapper import Guest
+
+
+def main(args, cijoe, step):
+    """Provision using an existing boot image"""
+
+    guest_name = step.get("with", {}).get("guest_name", None)
+    if guest_name is None:
+        log.error("missing step-argument: with.guest_name")
+        return errno.EINVAL
+
+    guest = Guest(cijoe, cijoe.config, guest_name)
+
+    if (
+        system_image_name := (
+            cijoe.config.options.get("qemu", {})
+            .get("guests", {})
+            .get(guest_name, {})
+            .get(
+                "system_image_name", step.get("with", {}).get("system_image_name", None)
+            )
+        )
+    ) is None:
+        log.error("qemu.guests.THIS.system_args.system_image_name is not set")
+        return errno.EINVAL
+
+    if (
+        disk := (
+            cijoe.config.options.get("system-imaging", {})
+            .get("images", {})
+            .get(system_image_name, {})
+            .get("disk", None)
+        )
+    ) is None:
+        log.error(f"system-imaging.images.{system_image_name}.disk is not set")
+        return errno.EINVAL
+
+    if not (diskimage_path := Path(disk.get("path"))).exists():
+        if (disk_url := disk.get("url", None)) is None:
+            log.error(
+                f"Cannot download; no 'url' in configuration-file for disk({disk})"
+            )
+            return errno.EINVAL
+
+        diskimage_path.parent.mkdir(exist_ok=True, parents=True)
+
+        disk_url_checksum = disk.get("url_checksum")
+        err, path = (
+            download_and_verify(disk_url, disk_url_checksum, diskimage_path)
+            if disk_url_checksum
+            else download(disk_url, diskimage_path)
+        )
+        if err:
+            log.error(f"err({err}, path({path})")
+            return err
+
+    err = guest.initialize(diskimage_path)
+    if err:
+        log.error(f"guest.initialize({diskimage_path}); err({err})")
+        return err
+
+    return 0

--- a/scripts/cijoe/scripts/qemu_guest_start_custom_nvme.py
+++ b/scripts/cijoe/scripts/qemu_guest_start_custom_nvme.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+Start a qemu-guest with NVMe devices
+====================================
+
+This creates a configuration, which on a recent Linux installation would be
+something like:
+
+* /dev/ng0n1 -- nvm
+* /dev/ng0n2 -- zns
+
+* /dev/ng1n1 -- nvm
+
+* /dev/ng2n1 -- nvm (mdts=0 / unlimited)
+* /dev/ng3n1 -- fdp-enabled subsystem and nvm namespace
+
+Using the the 'ng' device-handle, as it is always available, whereas 'nvme' are
+only for block-devices. Regardless, the above is just to illustrate one
+possible "appearance" of the devices in Linux.
+
+Retargetable: false
+-------------------
+"""
+import errno
+import logging as log
+from pathlib import Path
+
+from cijoe.qemu.wrapper import Guest
+
+
+def qemu_nvme_args(nvme_img_root):
+    """
+    Returns list of drive-args and a string of qemu-arguments
+
+    @returns drives, args
+    """
+
+    lbads = 12
+
+    def subsystem(id, nqn=None, aux={}):
+        """
+        Generate a subsystem configuration
+        @param id Identifier, could be something like 'subsys0'
+        @param nqn Non-qualified-name, assigned verbatim when provided
+        @param aux Auxilary arguments, e.g. add {fdp: on} here, to enable fdp
+        """
+
+        args = {"id": id}
+        if nqn:
+            args["nqn"] = nqn
+        args.update(aux)
+
+        return [
+            "-device",
+            ",".join(["nvme-subsys"] + [f"{k}={v}" for k, v in args.items()]),
+        ]
+
+    def controller(
+        id, serial, mdts, downstream_bus, upstream_bus, controller_slot, subsystem=None
+    ):
+        args = {
+            "id": id,
+            "serial": serial,
+            "bus": downstream_bus,
+            "mdts": mdts,
+            "ioeventfd": "on",
+        }
+        if subsystem:
+            args["subsys"] = subsystem
+
+        return [
+            "-device",
+            f"xio3130-downstream,id={downstream_bus},"
+            f"bus={upstream_bus},chassis=2,slot={controller_slot}",
+            "-device",
+            ",".join(["nvme"] + [f"{k}={v}" for k, v in args.items()]),
+        ]
+
+    def namespace(controller_id, nsid, aux={}):
+        """Returns qemu-arguments for a namespace configuration"""
+
+        drive_id = f"{controller_id}n{nsid}"
+        drive = {
+            "id": drive_id,
+            "file": str(nvme_img_root / f"{drive_id}.img"),
+            "format": "raw",
+            "if": "none",
+            "discard": "on",
+            "detect-zeroes": "unmap",
+        }
+        # drives.append(drive1)
+        controller_namespace = {
+            "id": drive_id,
+            "drive": drive_id,
+            "bus": controller_id,
+            "nsid": nsid,
+            "logical_block_size": 1 << lbads,
+            "physical_block_size": 1 << lbads,
+            **aux,
+        }
+
+        return drive, [
+            "-drive",
+            ",".join(f"{k}={v}" for k, v in drive.items()),
+            "-device",
+            ",".join(
+                ["nvme-ns"] + [f"{k}={v}" for k, v in controller_namespace.items()]
+            ),
+        ]
+
+    drives = []
+
+    # NVMe configuration arguments
+    nvme = []
+    nvme += ["-device", "pcie-root-port,id=pcie_root_port1,chassis=1,slot=1"]
+
+    upstream_bus = "pcie_upstream_port1"
+    nvme += ["-device", f"x3130-upstream,id={upstream_bus},bus=pcie_root_port1"]
+
+    #
+    # Nvme0 - Controller for functional verification of namespaces with NVM and ZNS
+    # command-sets
+    #
+    controller_id1 = "nvme0"
+    controller_bus1 = "pcie_downstream_port1"
+    controller_slot1 = 1
+    nvme += controller(
+        controller_id1, "deadbeef", 7, controller_bus1, upstream_bus, controller_slot1
+    )
+
+    # Nvme0n1 - NVM namespace
+    drive1, qemu_nvme_dev1 = namespace(controller_id1, 1)
+    nvme += qemu_nvme_dev1
+    drives.append(drive1)
+
+    # Nvme0n2 - ZNS namespace
+    zoned_attributes = {
+        "zoned": "on",
+        "zoned.zone_size": "32M",
+        "zoned.zone_capacity": "28M",
+        "zoned.max_active": 256,
+        "zoned.max_open": 256,
+        "zoned.zrwas": 32 << lbads,
+        "zoned.zrwafg": 16 << lbads,
+        "zoned.numzrwa": 256,
+    }
+
+    drive2, qemu_nvme_dev2 = namespace(controller_id1, 2, zoned_attributes)
+    nvme += qemu_nvme_dev2
+    drives.append(drive2)
+
+    # Nvme1 - Controller dedicated to Fabrics testing
+    controller_id2 = "nvme1"
+    controller_bus2 = "pcie_downstream_port2"
+    controller_slot2 = 2
+    nvme += controller(
+        controller_id2, "adcdbeef", 7, controller_bus2, upstream_bus, controller_slot2
+    )
+
+    # Nvme1n1 - Namespace with NVM command-set
+    drive3, qemu_nvme_dev3 = namespace(controller_id2, 1)
+    nvme += qemu_nvme_dev3
+    drives.append(drive3)
+
+    # Nvme2 - Controller dedicated to testing HUGEPAGES / Large MDTS
+    controller_id3 = "nvme2"
+    controller_bus3 = "pcie_downstream_port3"
+    controller_slot3 = 3
+    nvme += controller(
+        controller_id3, "beefcace", 0, controller_bus3, upstream_bus, controller_slot3
+    )
+
+    # Nvme2n1 - NVM namespace
+    drive4, qemu_nvme_dev4 = namespace(controller_id3, 1)
+    nvme += qemu_nvme_dev4
+    drives.append(drive4)
+
+    #
+    # Nvme4 - Controller with PI enabled
+    #
+
+    controller_id5 = "nvme4"
+    controller_bus5 = "pcie_downstream_port5"
+    controller_slot5 = 5
+    nvme += controller(
+        controller_id5, "feebdaed", 7, controller_bus5, upstream_bus, controller_slot5
+    )
+
+    # Nvme4n1 - NVM namespace with PI type 1
+    drv_pi1, qemu_nvme_dev_pi1 = namespace(controller_id5, 1, {"ms": 8, "pi": 1})
+    nvme += qemu_nvme_dev_pi1
+    drives.append(drv_pi1)
+
+    # Nvme4n2 - NVM namespace with PI type 2
+    drv_pi2, qemu_nvme_dev_pi2 = namespace(controller_id5, 2, {"ms": 8, "pi": 2})
+    nvme += qemu_nvme_dev_pi2
+    drives.append(drv_pi2)
+
+    # Nvme4n3 - NVM namespace with PI type 3
+    drv_pi3, qemu_nvme_dev_pi3 = namespace(controller_id5, 3, {"ms": 8, "pi": 3})
+    nvme += qemu_nvme_dev_pi3
+    drives.append(drv_pi3)
+
+    return drives, nvme
+
+
+def main(args, cijoe, step):
+    """Start a qemu guest"""
+
+    guest_name = step.get("with", {}).get("guest_name", None)
+    if guest_name is None:
+        log.error("missing step-argument: with.guest_name")
+        return 1
+
+    guest = Guest(cijoe, cijoe.config, guest_name)
+
+    drive_size = "8G"
+
+    nvme_img_root = Path(step.get("with", {}).get("nvme_img_root", guest.guest_path))
+
+    drives, nvme_args = qemu_nvme_args(nvme_img_root)
+
+    # Check that the backing-storage exists, create them if they do not
+    for drive in drives:
+        err, _ = cijoe.run_local(f"[ -f {drive['file']} ]")
+        if err:
+            guest.image_create(drive["file"], drive["format"], drive_size)
+        err, _ = cijoe.run_local(f"[ -f {drive['file']} ]")
+
+    err = guest.start(extra_args=nvme_args)
+    if err:
+        log.error(f"guest.start() : err({err})")
+        return err
+
+    started = guest.is_up()
+    if not started:
+        log.error("guest.is_up() : False")
+        return errno.EAGAIN
+
+    return 0

--- a/scripts/cijoe/workflows/autorun_in_qemu.yaml
+++ b/scripts/cijoe/workflows/autorun_in_qemu.yaml
@@ -1,0 +1,67 @@
+---
+doc: |
+  Create qemu guest, transfer SPDK .tgz source and invoke autorun
+
+  * Create qemu guest, and start it, using a system_image
+  * Transfer and unpack SPDK source to/in qemu guest
+  * Create auto.conf for testing (unittest + nvme)
+  * Invoke autorun.sh
+  * Retrieve autorun output
+  * Shut down qemu guest
+
+steps:
+- name: guest_initialize
+  uses: guest_initialize
+  with:
+    system_image_name: fedora-40-x86_64
+    guest_name: generic-bios-kvm-x86_64
+
+- name: guest_start
+  uses: qemu_guest_start_custom_nvme
+  with:
+    guest_name: generic-bios-kvm-x86_64
+
+- name: guest_check
+  run: |
+    hostname
+    uname -a
+
+- name: tgz_transfer
+  uses: core.put
+  with:
+    src: "{{ local.env.REPOSITORY_TARBALL_PATH }}"
+    dst: /tmp/repository.tar.gz
+
+- name: tgz_unpack
+  run: |
+    mkdir /opt/spdk
+    tar xzf /tmp/repository.tar.gz -C /opt/spdk
+    git config --global --add safe.directory /opt/spdk
+    
+- name: autorun_unittest
+  run: |
+    mkdir -p /opt/output/unittest
+    echo "SPDK_TEST_UNITTEST=1" > /tmp/auto.conf
+    output_dir=/opt/output/unittest /opt/spdk/autorun.sh /tmp/auto.conf
+
+- name: autorun_nvme
+  run: |
+    mkdir -p /opt/output/nvme
+    echo "SPDK_RUN_FUNCTIONAL_TEST=1" > /tmp/auto.conf
+    echo "SPDK_TEST_NVME=1" >> /tmp/auto.conf
+    output_dir=/opt/output/nvme /opt/spdk/autorun.sh /tmp/auto.conf
+
+- name: output_listing
+  run: |
+    ls /opt
+    ls /opt/output
+
+- name: retrieve_autorun_output
+  uses: core.get
+  with:
+    src: /opt/output
+    dst: /tmp/autorun_output
+     
+- name: guest_shutdown
+  run: |
+    systemctl poweroff

--- a/scripts/cijoe/workflows/build_qcow2_using_qemu.yaml
+++ b/scripts/cijoe/workflows/build_qcow2_using_qemu.yaml
@@ -1,0 +1,59 @@
+---
+doc: |
+  Create a Qemu Machine using a cloud-init image
+
+  * Cloud-init and shutdown
+  * Start the guest again -- check hostname, update and install git + pipx
+  * Transfer SPDK source to guest and unpack it
+  * Run pkgdep.sh and autotest_setup.sh to install dependencies
+
+  Then do the following (manually)
+  
+  * Convert the image (with compression)
+    - qemu-img convert boot.img /tmp/debian-bullseye-amd64.qcow2 -O qcow2 -c
+  * Upload it to publically available storage
+
+steps:
+- name: guest_kill
+  uses: qemu.guest_kill
+
+- name: guest_cloudinit
+  uses: qemu.guest_init_using_cloudinit
+
+- name: guest_firstboot
+  uses: qemu_guest_start_custom_nvme
+
+- name: guest_check
+  run: |
+    hostname
+    uname -a
+
+- name: guest_update
+  run: |
+    dnf update -y
+    dnf install -y git perl-JSON-PP
+    dnf autoremove -y
+
+- name: guest_info
+  uses: linux.sysinfo
+
+- name: tgz_transfer
+  uses: core.put
+  with:
+    src: "{{ local.env.REPOSITORY_TARBALL_PATH }}"
+    dst: /tmp/repository.tar.gz
+
+- name: tgz_unpack
+  run: |
+    mkdir /tmp/spdk
+    tar xzf /tmp/repository.tar.gz -C /tmp/spdk
+    
+- name: pkgdep_and_autotest_setup
+  run: |
+    /tmp/spdk/scripts/pkgdep.sh -a
+    /tmp/spdk/test/common/config/autotest_setup.sh --install-deps --upgrade --test-conf="flamegraph,fio,lcov,nvmecli"
+    
+- name: guest_shutdown
+  run: |
+    sync
+    systemctl poweroff


### PR DESCRIPTION
This removes the gerrit-integration that was done on:

  https://github.com/spdk-community-ci/dispatcher

The CI jobs and workflows need slight adjustments, as they assumed the
SPDK repository was "external." This assumption, along with reporting to
Gerrit, is removed. And in addition:

* Replaced the use of Self-Hosted runners with GitHUB Hosted

  - This is done to evaluate how much functional verification we can
    achieve without adding more capable self-hosted runners
  - Reduced the VM core count from 12 to 8, going down to 4 fails lcore
    tests

* Switched "ci-env" to using ghcr.io/refenv/cijoe-docker:v0.9.47

  - This removes the need to maintain a "spdk-github-ci-docker-image"
  - Adjusted to changes in CIJOE v0.9.47 (eg. guest initialization)
  - By using this, then we leverage the work of CIJOE and other projects
    using it do to nested virtualization e.g. the xNVMe project

* Adjusted the CIJOE workflow to fix overship of github repository

* Refactored the GHA "autorun" workflow

  - Split into parallel runs -- reducing total processing time
  - Re-wrote to avoid redundant descriptions by using "matrix.workflow",
    e.g. parametrized the job-logic

The "autorun.yml" is the only of the provided workflows that have been
"ported", the remaining need a bit more work (qcow image generation,
self-hosted-runner maintenance). But this, can get the ball rolling.. so
to speak.

This runs the tests inside qemu-guests (VMs) with .qcow2 images that
are generated for the task to ensure proper execution environment.
The qemu-guests allows for NVMe device emulation, thereby testing
NVMe Command-sets that are not commonly available such as ZNS, and a
variation of controller parameters such as MDTS size.

Places the CIJOE scripts inside the SPDK "scripts/cijoe" as it seems
like the most appropriate place to put them.