### PR TITLE
github: add workflows for handling Gerrit webhooks

### DIFF
--- a/.github/workflows/gerrit-change-printer.yml
+++ b/.github/workflows/gerrit-change-printer.yml
@@ -1,0 +1,23 @@
+name: Print Gerrit patchset data
+
+on:
+  workflow_call:
+    inputs:
+      patchset_ref:
+        required: false
+        default: ''
+        type: string
+      patchset_rev:
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  print-patchset:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print patchset ref & revision
+        run: |
+          echo "Webhook Payload - patch set ref & hash:"
+          echo "${{ inputs.patchset_ref }}"
+          echo "${{ inputs.patchset_rev }}"

--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -1,0 +1,16 @@
+name: Handle gerrit webhook
+
+on:
+  repository_dispatch:
+    types:
+      - gerrit-webhook
+
+jobs:
+  # "print-stuff" is only an example job entry, which is reusing "gerrint-change-printer" workflow.
+  # Ultimately it should be replaced by other workflows and actions running SPDK tests
+  print-stuff:
+    uses: karlatec/spdk/.github/workflows/gerrit-change-printer.yml@master
+    with:
+      # "Client payload" is all of the information Gerrit webhooks sends out.
+      patchset_ref: ${{ github.event.client_payload.patchSet.ref }}
+      patchset_rev: ${{ github.event.client_payload.patchSet.revision }}


### PR DESCRIPTION
Webhook handler workflow reacts to webhooks received from the Gerrit instance, and acts as a trigger for executing sub-builds with actual tests, while also passing all necessary information as patchset refspec, revision, uploader, etc.