### PR TITLE
Poll the ongoing requests to be completed before cleanup fio thread.

### DIFF
--- a/app/fio/bdev/fio_plugin.c
+++ b/app/fio/bdev/fio_plugin.c
@@ -813,7 +813,7 @@ static void
 spdk_fio_cleanup(struct thread_data *td)
 {
 	struct spdk_fio_thread *fio_thread = td->io_ops_data;
-
+	while (spdk_fio_poll_thread(fio_thread) > 0) {};
 	spdk_fio_cleanup_thread(fio_thread);
 	td->io_ops_data = NULL;
 }


### PR DESCRIPTION
At `spdk_fio_completion_cb`, the SPDK thread will use `td->io_ops_data`.
When the cleans up `fio_thread` before some ongoing requests call `spdk_fio_completion_cb`, a NULL pointer will issue a segmentation fault.
We need to poll all the requests to be done before we free `fio_thread`.

This issue is more likely happening when using fio iolog replay version 2.