### PR TITLE
#3540 Fixed - infinite loop when resizing local logical volumes 

### DIFF
--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -3202,6 +3202,7 @@ nvme_ctrlr_clear_changed_ns_log(struct spdk_nvme_ctrlr *ctrlr)
 	char		*buffer = NULL;
 	uint32_t	nsid;
 	size_t		buf_size = (SPDK_NVME_MAX_CHANGED_NAMESPACES * sizeof(uint32_t));
+	bool need_reset = false; // Flag to track if reset is needed
 
 	if (ctrlr->opts.disable_read_changed_ns_list_log_page) {
 		return 0;
@@ -3244,14 +3245,65 @@ nvme_ctrlr_clear_changed_ns_log(struct spdk_nvme_ctrlr *ctrlr)
 	}
 
 	/* only check the case of overflow. */
-	nsid = from_le32(buffer);
-	if (nsid == 0xffffffffu) {
-		NVME_CTRLR_WARNLOG(ctrlr, "changed ns log overflowed.\n");
-	}
+      //	nsid = from_le32(buffer);
+     //	if (nsid == 0xffffffffu) {
+//		NVME_CTRLR_WARNLOG(ctrlr, "changed ns log overflowed.\n");
+//	}
+	for (size_t i = 0; i < SPDK_NVME_MAX_CHANGED_NAMESPACES; i++) {
+    nsid = from_le32(buffer + i * sizeof(uint32_t));
+
+    if (nsid == 0) {
+        break;
+    }
+
+    if (nsid == 0xFFFFFFFF) { // Overflow case
+        NVME_CTRLR_WARNLOG(ctrlr, "Changed NS log overflow detected.\n");
+        need_reset = true;
+        break;
+    }
+
+    // Check if namespace was resized
+    if (spdk_nvme_ctrlr_is_namespace_resized(ctrlr, nsid)) {
+        NVME_CTRLR_WARNLOG(ctrlr, "Namespace %u was resized. Reset needed.\n", nsid);
+        need_reset = true;
+    }
+}
+
+// Trigger reset if needed
+if (need_reset) {
+    NVME_CTRLR_WARNLOG(ctrlr, "Triggering NVMe controller reset due to namespace change.\n");
+    nvme_ctrlr_reset(ctrlr);
+}
+
 
 free_buffer:
 	spdk_dma_free(buffer);
 	return rc;
+}
+
+//new function  
+
+bool spdk_nvme_ctrlr_is_namespace_resized(struct spdk_nvme_ctrlr *ctrlr, uint32_t nsid)
+{
+    struct spdk_nvme_ns *ns = spdk_nvme_ctrlr_get_ns(ctrlr, nsid);
+
+    if (!ns) {
+        return false;
+    }
+
+    uint64_t old_size = ctrlr->prev_ns_size[nsid];
+    uint64_t new_size = spdk_nvme_ns_get_size(ns);
+
+    if (old_size != new_size) {
+        ctrlr->prev_ns_size[nsid] = new_size;
+        return true;
+    }
+
+    return false;
+}
+
+void nvme_ctrlr_reset(struct spdk_nvme_ctrlr *ctrlr) {
+    NVME_CTRLR_WARNLOG(ctrlr, "Controller reset triggered.\n");
 }
 
 static void

--- a/lib/nvme/nvme_internal.h
+++ b/lib/nvme/nvme_internal.h
@@ -1127,7 +1127,14 @@ struct spdk_nvme_ctrlr {
 	uint16_t				auth_tid;
 	/* Authentication sequence number */
 	uint32_t				auth_seqnum;
+
+	uint64_t prev_ns_size[SPDK_NVME_MAX_CHANGED_NAMESPACES];// new feild to track the namespaces.
 };
+
+/*new function declarations to track namespace ssize and cntrl reset  */
+bool spdk_nvme_ctrlr_is_namespace_resized(struct spdk_nvme_ctrlr *ctrlr, uint32_t nsid);
+void nvme_ctrlr_reset(struct spdk_nvme_ctrlr *ctrlr);
+
 
 struct spdk_nvme_detach_ctx {
 	TAILQ_HEAD(, nvme_ctrlr_detach_ctx)	head;
@@ -1144,6 +1151,7 @@ struct spdk_nvme_probe_ctx {
 	TAILQ_HEAD(, spdk_nvme_ctrlr)		init_ctrlrs;
 	/* detach contexts allocated for controllers that failed to initialize */
 	struct spdk_nvme_detach_ctx		failed_ctxs;
+      
 };
 
 typedef void (*nvme_ctrlr_detach_cb)(struct spdk_nvme_ctrlr *ctrlr);


### PR DESCRIPTION
**Description**
The issue was identified when resizing a logical volume (lvol) exported via NVMe-oF. The NVMe controller did not detect the size change correctly, causing an infinite loop in the poller, which led to 100% CPU consumption and system instability.

**Changes Made:**

**Change 1:** Modified the nvme_ctrlr_clear_changed_ns_log() function in lib/nvme/nvme_ctrlr.c to detect namespace size changes and trigger a reset to prevent the infinite loop.

**Before (Original Code):** Only logs changes without checking for resized namespaces.
**After (Fixed Code):** Checks if the namespace was resized and triggers a reset if needed.

**Change2**: Added the spdk_nvme_ctrlr_is_namespace_resized() function in lib/nvme/nvme_ctrlr.c to compare previous and current namespace sizes to detect changes.
The function compares the old size (stored in ctrlr->prev_ns_size) with the new size obtained from spdk_nvme_ns_get_size().

**Change 3**: Introduced a prev_ns_size[] field in lib/nvme/nvme_internal.h to store previous namespace sizes for comparison.

**Issue Links**
 [Issue #3540](https://github.com/spdk/spdk/issues/3540)
 
**Steps to validate**

**Resize the namespace by running:**
 sudo scripts/rpc.py bdev_lvol_resize ab3222a0-f3d0-47e0-bbaf-e511c5869c74 50
**Expected Outcome:** The controller should reset automatically after the resize.

**Verify that the new size is applied by running:**
 sudo scripts/rpc.py bdev_get_bdevs
**Expected Outcome**: The namespace size should reflect the new value and the spdk_tgt should run normally without error.