### PR TITLE
Fix the abnormal execution of the "./scripts/pkgdep.sh" script in ubuntu24 environment

### DIFF
--- a/scripts/pkgdep/ubuntu.sh
+++ b/scripts/pkgdep/ubuntu.sh
@@ -1,1 +1,1 @@
-debian.sh
+./scripts/pkgdep/debian.sh


### PR DESCRIPTION
When running the "./scripts/pkgdep.sh" script in Ubuntu 20.04, the prompt "scripts/pkgdep/ubuntu.sh: line 1: debian.sh: command not found" appears , issue is https://github.com/spdk/spdk/issues/3632
![1](https://github.com/user-attachments/assets/a3378f11-7202-4acb-90dc-35af38d584ac)

Enter the pkgdep directory, check the file list with ls, and find that the ubuntu.sh file has no execution permission：
![2](https://github.com/user-attachments/assets/65396364-f0fb-43d4-b92f-967a2c802ac6)

Add execution permissions to ubuntu.sh
![3](https://github.com/user-attachments/assets/eaca0915-1958-4fc5-8545-ac69ac3bf6fe)

Then return to the parent directory and execute ./scripts/pkgdep.sh
![4](https://github.com/user-attachments/assets/834e4f83-66cd-4052-8096-ff7640010c4a)

As you can see, it prompts "debian.sh: command not found" again。After checking the file path, I found that debian.sh is in the subdirectory pkgdep, not in the current directory scripts, so I had to add a relative path to ubuntu.sh.
![5](https://github.com/user-attachments/assets/9b87192e-bb0f-4aaf-9d89-1cd558557f12)

At this point, execute "pkgdep.sh" again to prompt that the installation is successful。
![6](https://github.com/user-attachments/assets/c0e08ee9-9aa4-4a76-b1c0-ffe28415d2fe)

