### PR TITLE
fix:SPDK acts as a SCSI target, a host performs the following operati…

### DIFF
--- a/lib/scsi/scsi_pr.c
+++ b/lib/scsi/scsi_pr.c
@@ -164,6 +164,9 @@ scsi_pr_replace_registrant_key(struct spdk_scsi_lun *lun,
 {
 	SPDK_DEBUGLOG(scsi, "REGISTER: replace with new "
 		      "reservation key 0x%"PRIx64"\n", sa_rkey);
+	if (lun->reservation.holder == reg) {
+		lun->reservation.crkey = sa_rkey;
+	}
 	reg->rkey = sa_rkey;
 	lun->pr_generation++;
 }


### PR DESCRIPTION
…ons on a specific IT nexus:

1. Register & Ignore Existing Key operation, SAK=0x0a, result OK

2. Reserve operation, RK=0x0a, result OK

3. Register & Ignore Existing Key operation, SAK=0x0b, RK=0x0a, result OK

4. Read Reservation operation - the expected query result should be RK=0x0b, but the actual result is RK=0x0a, which doesn't match expectations.

When a Register operation or Register & Ignore Existing Key operation changes the RKey of an already registered nexus, if that registered nexus is simultaneously the holder of the reservation, SPDK fails to change the holder's CKey. This leads to the Read Reservation operation retrieving the old RKey.