### PR TITLE
bdev/nvme: inherit transport default options when JSON does not override

### DIFF
--- a/module/bdev/nvme/bdev_nvme.c
+++ b/module/bdev/nvme/bdev_nvme.c
@@ -6234,6 +6234,8 @@ bdev_nvme_hotplug(void *arg)
 void
 spdk_bdev_nvme_get_opts(struct spdk_bdev_nvme_opts *opts, size_t opts_size)
 {
+	struct spdk_nvme_transport_opts drv_opts;
+
 	if (!opts) {
 		SPDK_ERRLOG("opts should not be NULL\n");
 		return;
@@ -6243,6 +6245,15 @@ spdk_bdev_nvme_get_opts(struct spdk_bdev_nvme_opts *opts, size_t opts_size)
 		SPDK_ERRLOG("opts_size should not be zero value\n");
 		return;
 	}
+
+	/* Update transport options */
+	spdk_nvme_transport_get_opts(&drv_opts, sizeof(drv_opts));
+	g_opts.rdma_srq_size = drv_opts.rdma_srq_size;
+	g_opts.rdma_max_cq_size = drv_opts.rdma_max_cq_size;
+	g_opts.rdma_cm_event_timeout_ms = drv_opts.rdma_cm_event_timeout_ms;
+	g_opts.poll_group_requests = drv_opts.poll_group_requests;
+	g_opts.rdma_umr_per_io = drv_opts.rdma_umr_per_io;
+	g_opts.tcp_connect_timeout_ms = drv_opts.tcp_connect_timeout_ms;
 
 	opts->opts_size = opts_size;
 


### PR DESCRIPTION
## Background
We are developing a tool that helps identify valuable, unmerged commits
from downstream forks and proposes them upstream after manual review.

During this process, we identified this change, which has already been
validated and merged in a downstream fork (Mellanox/spdk, https://github.com/Mellanox/spdk/commit/67499ca5a95ab9bde52ec8d7423eb1faf4a3357a), and addresses a real
configuration propagation issue between the bdev and NVMe transport
layers.

## Problem Description
Previously:

* If RDMA/TCP-related options were not specified in the bdev JSON
  configuration,
* Zero values were passed to the transport layer,
* Which implicitly disabled transport features (e.g. SRQ, CQ sizing),
  even though the transport layer defines its own defaults.

This behavior could lead to unexpected performance degradation or
functional changes without any explicit user misconfiguration.

## Solution
This PR initializes bdev NVMe options using the current transport
default options obtained via `spdk_nvme_transport_get_opts()`, and then
allows JSON configuration to override individual fields when explicitly
specified.

As a result:
* Default behavior now matches transport defaults,
* Explicit JSON configuration still takes precedence,
* Silent feature disablement is avoided.

## Impact
* Improves correctness and consistency of NVMe bdev configuration
* Prevents unintended disabling of RDMA/TCP transport features
* No behavior change for users who explicitly configure these options

## Notes
This PR is proposed after manual inspection and validation of the
downstream change. It is not generated automatically and is intended to
help upstream maintain consistency and robustness.

Feedback or suggestions on improving our downstream-to-upstream
discovery workflow are very welcome.

Thank you for your review.