### PR TITLE
configure: fix typo CONFI[PGO_USE] -> CONFIG[PGO_USE]

### DIFF
--- a/configure
+++ b/configure
@@ -1185,7 +1185,7 @@ fi
 if [[ "${CONFIG[PGO_CAPTURE]}" = "y" && "${CONFIG[PGO_USE]}" = "y" ]]; then
 	echo "ERROR: --enable-pgo-capture and --enable-pgo-use are mutually exclusive."
 	exit 1
-elif [[ "${CONFIG[PGO_CAPTURE]}" = "y" || "${CONFI[PGO_USE]}" = "y" ]]; then
+elif [[ "${CONFIG[PGO_CAPTURE]}" = "y" || "${CONFIG[PGO_USE]}" = "y" ]]; then
 	if [[ -z "${CONFIG[PGO_DIR]}" ]]; then
 		CONFIG[PGO_DIR]=$(realpath $rootdir/build/pgo)
 	fi


### PR DESCRIPTION
## Summary

Fix typo in the configure script where `CONFI[PGO_USE]` should be `CONFIG[PGO_USE]`.

This causes an **unbound variable** error when running the configure script with `set -eu`:

```
./configure: line 1177: PGO_USE: unbound variable
```

## Change

The variable name was missing the trailing `G` in `CONFIG` on line 1188.

Fixes: #3874

Signed-off-by: Ashutosh Kumar Singh <ashutoshkumarsingh0x@gmail.com>
