### PR TITLE
vhost/blk: validate packed descriptor buffer_id to prevent OOB access

### DIFF
--- a/lib/vhost/vhost_blk.c
+++ b/lib/vhost/vhost_blk.c
@@ -714,6 +714,12 @@ process_packed_blk_task(struct spdk_vhost_virtqueue *vq, uint16_t req_idx)
 	 */
 	task_idx = vhost_vring_packed_desc_get_buffer_id(vq, req_idx, &num_descs);
 
+	if (spdk_unlikely(task_idx >= vq->vring.size)) {
+		SPDK_ERRLOG("Guest provided out-of-bounds buffer_id %"PRIu16" (max %"PRIu16").\n",
+			    task_idx, vq->vring.size);
+		return;
+	}
+
 	task = &((struct spdk_vhost_user_blk_task *)vq->tasks)[task_idx];
 	blk_task = &task->blk_task;
 	if (spdk_unlikely(task->used)) {
@@ -775,6 +781,12 @@ process_packed_inflight_blk_task(struct spdk_vhost_virtqueue *vq,
 	if (vq->last_avail_idx >= vq->vring.size) {
 		vq->last_avail_idx -= vq->vring.size;
 		vq->packed.avail_phase = !vq->packed.avail_phase;
+	}
+
+	if (spdk_unlikely(task_idx >= vq->vring.size)) {
+		SPDK_ERRLOG("Inflight descriptor has out-of-bounds buffer_id %"PRIu16" (max %"PRIu16").\n",
+			    task_idx, vq->vring.size);
+		return;
 	}
 
 	task = &((struct spdk_vhost_user_blk_task *)vq->tasks)[task_idx];
@@ -991,6 +1003,13 @@ no_bdev_process_packed_vq(struct spdk_vhost_blk_session *bvsession, struct spdk_
 	}
 
 	task_idx = vhost_vring_packed_desc_get_buffer_id(vq, req_idx, &num_descs);
+
+	if (spdk_unlikely(task_idx >= vq->vring.size)) {
+		SPDK_ERRLOG("Guest provided out-of-bounds buffer_id %"PRIu16" (max %"PRIu16").\n",
+			    task_idx, vq->vring.size);
+		return;
+	}
+
 	task = &((struct spdk_vhost_user_blk_task *)vq->tasks)[task_idx];
 	blk_task = &task->blk_task;
 	if (spdk_unlikely(task->used)) {


### PR DESCRIPTION
## Summary

Fix a guest-triggerable out-of-bounds array access in the packed vhost-blk
request processing path. A malicious or buggy guest can craft a packed
descriptor with a `buffer_id` (desc->id) value >= `vq->vring.size`, which
is then used as an index into the host `vq->tasks[]` array without any
bounds validation.

## Root Cause

The `vq->tasks` array is allocated with exactly `vq->vring.size` elements
(valid indices: `0` to `vq->vring.size - 1`). The guest-provided packed
descriptor `id` field is used as the task index via
`vhost_vring_packed_desc_get_buffer_id()`, but no bounds check exists
before the array access.

## Impact

- **Minimum**: NULL pointer dereference -> denial of service (crash)
- **Potential**: If the OOB slot overlaps non-zero host memory, later
  accesses through fields like `bvsession`, `status`, `cb`, `cb_arg`
  could turn this into arbitrary read/write from the guest

## Fix

Add `task_idx >= vq->vring.size` validation in all three packed ring
task processing functions, consistent with the existing bounds checks
already present in the split ring path (`process_vq` line 879) and
the inflight resubmit path (`submit_inflight_desc` line 842):

1. `process_packed_blk_task()` - normal packed request path
2. `process_packed_inflight_blk_task()` - packed inflight recovery path
3. `no_bdev_process_packed_vq()` - no-bdev fallback path

All checks use `spdk_unlikely()` to avoid performance impact on the
hot path.

## Testing

Verified the fix prevents the SEGV reported in the original issue
using the QEMU qtest reproduction script provided in #3860.

Fixes: #3860
Signed-off-by: Ashutosh Kumar Singh <ashutoshkumarsingh0x@gmail.com>
