### PR TITLE
perf: fix inf IOPS/MiB/s when elapsed time is zero

### DIFF
--- a/app/spdk_nvme_perf/perf.c
+++ b/app/spdk_nvme_perf/perf.c
@@ -2005,8 +2005,13 @@ print_performance(void)
 	TAILQ_FOREACH(worker, &g_workers, link) {
 		TAILQ_FOREACH(ns_ctx, &worker->ns_ctx, link) {
 			if (ns_ctx->stats.io_completed != 0) {
-				io_per_second = (double)ns_ctx->stats.io_completed * 1000 * 1000 / g_elapsed_time_in_usec;
-				mb_per_second = io_per_second * g_io_size_bytes / (1024 * 1024);
+				if (g_elapsed_time_in_usec == 0) {
+					io_per_second = 0.0;
+					mb_per_second = 0.0;
+				} else {
+					io_per_second = (double)ns_ctx->stats.io_completed * 1000 * 1000 / g_elapsed_time_in_usec;
+					mb_per_second = io_per_second * g_io_size_bytes / (1024 * 1024);
+				}
 				average_latency = ((double)ns_ctx->stats.total_tsc / ns_ctx->stats.io_completed) * 1000 * 1000 /
 						  g_tsc_rate;
 				min_latency = (double)ns_ctx->stats.min_tsc * 1000 * 1000 / g_tsc_rate;


### PR DESCRIPTION
Reproduce with:
  timeout 30 ./build/bin/spdk_nvme_perf -q 2048 -o 1048576 -w randread -t 30     -c 0x100000000     -r 'trtype:PCIe traddr:0000:21:00.0'     -r 'trtype:PCIe traddr:0000:22:00.0'     -r 'trtype:PCIe traddr:0000:41:00.0'     -r 'trtype:PCIe traddr:0000:42:00.0'     -r 'trtype:PCIe traddr:0000:81:00.0'     -r 'trtype:PCIe traddr:0000:82:00.0'     -r 'trtype:PCIe traddr:0000:c1:00.0'     -r 'trtype:PCIe traddr:0000:c2:00.0'

Before fix, result:
  IOPS, MiB/s = inf
After fix, result:
  IOPS, MiB/s = 0.00 when elapsed time is zero

Check g_elapsed_time_in_usec before division to avoid inf output in performance results.